### PR TITLE
SSCS-1863 SMS confirmation

### DIFF
--- a/steps/sms-notify/sms-confirmation/SmsConfirmation.js
+++ b/steps/sms-notify/sms-confirmation/SmsConfirmation.js
@@ -8,7 +8,7 @@ class SmsConfirmation extends Question {
     }
 
     get template() {
-        return `sms-notify/sms-confirmation/template`;
+        return 'sms-notify/sms-confirmation/template';
     }
 
     get i18NextContent() {

--- a/steps/sms-notify/sms-confirmation/SmsConfirmation.js
+++ b/steps/sms-notify/sms-confirmation/SmsConfirmation.js
@@ -1,5 +1,5 @@
 const { Question, goTo } = require('@hmcts/one-per-page');
-// const content = require('./content');
+const content = require('./content');
 
 class SmsConfirmation extends Question {
 
@@ -11,14 +11,14 @@ class SmsConfirmation extends Question {
         return `sms-notify/sms-confirmation/template`;
     }
 
-    // get i18NextContent() {
-    //     return content;
-    // }
+    get i18NextContent() {
+        return content;
+    }
 
     get form() {}
 
     next() {
-        return goTo(undefined); // To define the next step
+        return goTo(this.journey.Representative);
     }
 }
 

--- a/steps/sms-notify/sms-confirmation/content.json
+++ b/steps/sms-notify/sms-confirmation/content.json
@@ -4,6 +4,7 @@
       "title": "You’re signed up for text message reminders",
       "mobileNumber": "Text messages will be sent to the following number: ",
       "firstMessage": "You’ll get your first message after you’ve submitted your appeal.",
+      "continue": "Continue",
       "change": "Change number"
     }
   }

--- a/steps/sms-notify/sms-confirmation/content.json
+++ b/steps/sms-notify/sms-confirmation/content.json
@@ -1,1 +1,10 @@
-{}
+{
+  "en": {
+    "translation": {
+      "title": "You’re signed up for text message reminders",
+      "mobileNumber": "Text messages will be sent to the following number: ",
+      "firstMessage": "You’ll get your first message after you’ve submitted your appeal.",
+      "change": "Change number"
+    }
+  }
+}

--- a/steps/sms-notify/sms-confirmation/template.html
+++ b/steps/sms-notify/sms-confirmation/template.html
@@ -1,25 +1,26 @@
-{% extends "look-and-feel/layouts/question.html" %}
+{% extends "look-and-feel/layouts/two_thirds.html" %}
+{% from "look-and-feel/components/phase_banner.njk" import phaseBanner %}
 {% from "look-and-feel/components/header.njk" import header %}
-{% from "look-and-feel/components/fields.njk" import textbox, formSection %}
+{% set phase="ALPHA" %}
+{% set feedbackLink="https://github.com/hmcts/one-per-page/issues/new" %}
 
 {% block head -%}
     <link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
 {% endblock %}
 
-{% set phase="ALPHA" %}
-{% set feedbackLink="https://github.com/hmcts/one-per-page/issues/new" %}
+{% block breadcrumbs %}
+    {{ phaseBanner(phase, feedbackLink) }}
+    <a class="link-back" href="#" onclick="history.go(-1)">Back</a>
+{% endblock %}
 
-{% set title %}
-    {{ content.title | safe }}
-{% endset %}
-
-{% block fields %}
-
-    {% call formSection() %}
-
-        <p>{{ content.mobileNumber | safe }}</p>
-        <p>{{ content.firstMessage | safe }}</p>
-
-    {% endcall %}
-
+{% block two_thirds %}
+    {{ header(content.title, size="large") }}
+    <p>{{ content.mobileNumber }}
+        <span class="bold-small">
+            {{ session.EnterMobile_mobileNumber if session.EnterMobile_mobileNumber else session.AppellantDetails_phoneNumber }}
+        </span>
+    </p>
+    <p>{{ content.firstMessage }}</p>
+    <p><a class="button" href="/representative">{{ content.continue }}</a></p>
+    <p><a class="link" href="/enter-mobile">{{ content.change }}</a></p>
 {% endblock %}

--- a/steps/sms-notify/sms-confirmation/template.html
+++ b/steps/sms-notify/sms-confirmation/template.html
@@ -1,12 +1,25 @@
-{% extends "look-and-feel/layouts/two_thirds.html" %}
-{% from "look-and-feel/components/phase_banner.njk" import phaseBanner %}
+{% extends "look-and-feel/layouts/question.html" %}
 {% from "look-and-feel/components/header.njk" import header %}
+{% from "look-and-feel/components/fields.njk" import textbox, formSection %}
 
 {% block head -%}
-<link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
+    <link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
 {% endblock %}
 
-{% block two_thirds %}
-<a class="link-back" href="#" onclick="history.go(-1)">Back</a>
-<h1>SMS CONFIRMATION PLACEHOLDER TEXT</h1>
+{% set phase="ALPHA" %}
+{% set feedbackLink="https://github.com/hmcts/one-per-page/issues/new" %}
+
+{% set title %}
+    {{ content.title | safe }}
+{% endset %}
+
+{% block fields %}
+
+    {% call formSection() %}
+
+        <p>{{ content.mobileNumber | safe }}</p>
+        <p>{{ content.firstMessage | safe }}</p>
+
+    {% endcall %}
+
 {% endblock %}


### PR DESCRIPTION
Add SMS-confirmation page.
Add template with link to go back to the enter-mobile step and link to progress to the representative step. Display the number the user has entered. If mobile number has been entered in the `/enter-mobile` step then display that else display the appellant phone number entered in the `appellant-details` step.
Add content to the json file.