### PR TITLE
Fix enter mobile unit test for get form()

### DIFF
--- a/test/unit/steps/sms-notify/enter-mobile/EnterMobile.test.js
+++ b/test/unit/steps/sms-notify/enter-mobile/EnterMobile.test.js
@@ -42,7 +42,11 @@ describe('EnterMobile.js', () => {
 
     describe('get form()', () => {
 
-        let field = enterMobileClass.form.fields[0];
+        let field;
+
+        beforeEach(() => {
+            field = enterMobileClass.form.fields[0];
+        });
 
         after(() => {
             field = undefined;


### PR DESCRIPTION
Add beforeEach when assigning field for variable as a new class is instantiated before each test