### PR TITLE
Identity section unit tests

### DIFF
--- a/test/unit/steps/identity/appellant-details/AppellantDetails.test.js
+++ b/test/unit/steps/identity/appellant-details/AppellantDetails.test.js
@@ -1,0 +1,217 @@
+'use strict';
+
+const { expect } = require('test/util/chai');
+const AppellantDetails = require('steps/identity/appellant-details/AppellantDetails');
+const content = require('steps/identity/appellant-details/content.json');
+const urls = require('urls');
+
+describe('AppellantDetails.js', () => {
+
+    let appellantDetailsClass;
+
+    beforeEach(() => {
+        appellantDetailsClass = new AppellantDetails();
+    });
+
+    after(() => {
+        appellantDetailsClass = undefined;
+    });
+
+    describe('get url()', () => {
+
+        it('returns url /enter-appellant-details', () => {
+            expect(appellantDetailsClass.url).to.equal(urls.identity.enterAppellantDetails);
+        });
+
+    });
+
+    describe('get template()', () => {
+
+        it('returns template path identity/appellant-details/template', () => {
+            expect(appellantDetailsClass.template).to.equal('identity/appellant-details/template');
+        });
+
+    });
+
+    describe('get i18NextContent()', () => {
+
+        it('returns the correct content for the page', () => {
+            expect(appellantDetailsClass.i18NextContent).to.equal(content);
+        });
+
+    });
+
+    describe('get form()', () => {
+
+        let fields;
+        let field;
+
+        beforeEach(() => {
+            fields = appellantDetailsClass.form.fields;
+        });
+
+        after(() => {
+            fields = field = undefined;
+        });
+
+        describe('firstName field', () => {
+
+            beforeEach(() => {
+                field = fields[0];
+            });
+
+            it('contains the field name firstName', () => {
+                expect(field.name).to.equal('firstName');
+            });
+
+            it('contains field content', () => {
+                expect(field.content).to.eql(content.en.translation.fields.firstName);
+            });
+
+        });
+
+        describe('lastName field', () => {
+
+            beforeEach(() => {
+                field = fields[1];
+            });
+
+            it('contains the field name lastName', () => {
+                expect(field.name).to.equal('lastName');
+            });
+
+            it('contains field content', () => {
+                expect(field.content).to.eql(content.en.translation.fields.lastName);
+            });
+
+        });
+
+        describe('niNumber field', () => {
+
+            beforeEach(() => {
+                field = fields[2];
+            });
+
+            it('contains the field name niNumber', () => {
+                expect(field.name).to.equal('niNumber');
+            });
+
+            it('contains field content', () => {
+                expect(field.content).to.eql(content.en.translation.fields.niNumber);
+            });
+
+        });
+
+        describe('addressLine1 field', () => {
+
+            beforeEach(() => {
+                field = fields[3];
+            });
+
+            it('contains the field name addressLine1', () => {
+                expect(field.name).to.equal('addressLine1');
+            });
+
+            it('contains field content', () => {
+                expect(field.content).to.eql(content.en.translation.fields.addressLine1);
+            });
+
+        });
+
+        describe('addressLine2 field', () => {
+
+            beforeEach(() => {
+                field = fields[4];
+            });
+
+            it('contains the field name addressLine2', () => {
+                expect(field.name).to.equal('addressLine2');
+            });
+
+            it('contains field content', () => {
+                expect(field.content).to.eql(content.en.translation.fields.addressLine2);
+            });
+
+        });
+
+        describe('townCity field', () => {
+
+            beforeEach(() => {
+                field = fields[5];
+            });
+
+            it('contains the field name townCity', () => {
+                expect(field.name).to.equal('townCity');
+            });
+
+            it('contains field content', () => {
+                expect(field.content).to.eql(content.en.translation.fields.townCity);
+            });
+
+        });
+
+        describe('postCode field', () => {
+
+            beforeEach(() => {
+                field = fields[6];
+            });
+
+            it('contains the field name postCode', () => {
+                expect(field.name).to.equal('postCode');
+            });
+
+            it('contains field content', () => {
+                expect(field.content).to.eql(content.en.translation.fields.postCode);
+            });
+
+        });
+
+        describe('phoneNumber field', () => {
+
+            beforeEach(() => {
+                field = fields[7];
+            });
+
+            it('contains the field name phoneNumber', () => {
+                expect(field.name).to.equal('phoneNumber');
+            });
+
+            it('contains field content', () => {
+                expect(field.content).to.eql(content.en.translation.fields.phoneNumber);
+            });
+
+        });
+
+        describe('emailAddress field', () => {
+
+            beforeEach(() => {
+                field = fields[8];
+            });
+
+            it('contains the field name emailAddress', () => {
+                expect(field.name).to.equal('emailAddress');
+            });
+
+            it('contains field content', () => {
+                expect(field.content).to.eql(content.en.translation.fields.emailAddress);
+            });
+
+        });
+
+    });
+
+    describe('next()', () => {
+
+        it('returns the next step url /appellant-text-reminders', () => {
+            const redirector = {
+                nextStep: urls.smsNotify.appellantTextReminders
+            };
+            appellantDetailsClass.journey = {
+                TextReminders: urls.smsNotify.appellantTextReminders
+            };
+            expect(appellantDetailsClass.next()).to.eql(redirector);
+        });
+
+    });
+
+});

--- a/test/unit/steps/identity/appellant-details/AppellantDetails.test.js
+++ b/test/unit/steps/identity/appellant-details/AppellantDetails.test.js
@@ -64,8 +64,8 @@ describe('AppellantDetails.js', () => {
                 expect(field.name).to.equal('firstName');
             });
 
-            it('contains field content', () => {
-                expect(field.content).to.eql(content.en.translation.fields.firstName);
+            it('contains validation', () => {
+                expect(field.validations).to.not.be.empty;
             });
 
         });
@@ -80,8 +80,8 @@ describe('AppellantDetails.js', () => {
                 expect(field.name).to.equal('lastName');
             });
 
-            it('contains field content', () => {
-                expect(field.content).to.eql(content.en.translation.fields.lastName);
+            it('contains validation', () => {
+                expect(field.validations).to.not.be.empty;
             });
 
         });
@@ -96,8 +96,8 @@ describe('AppellantDetails.js', () => {
                 expect(field.name).to.equal('niNumber');
             });
 
-            it('contains field content', () => {
-                expect(field.content).to.eql(content.en.translation.fields.niNumber);
+            it('contains validation', () => {
+                expect(field.validations).to.not.be.empty;
             });
 
         });
@@ -112,8 +112,8 @@ describe('AppellantDetails.js', () => {
                 expect(field.name).to.equal('addressLine1');
             });
 
-            it('contains field content', () => {
-                expect(field.content).to.eql(content.en.translation.fields.addressLine1);
+            it('contains validation', () => {
+                expect(field.validations).to.not.be.empty;
             });
 
         });
@@ -128,8 +128,8 @@ describe('AppellantDetails.js', () => {
                 expect(field.name).to.equal('addressLine2');
             });
 
-            it('contains field content', () => {
-                expect(field.content).to.eql(content.en.translation.fields.addressLine2);
+            it('contains validation', () => {
+                expect(field.validations).to.not.be.empty;
             });
 
         });
@@ -144,8 +144,8 @@ describe('AppellantDetails.js', () => {
                 expect(field.name).to.equal('townCity');
             });
 
-            it('contains field content', () => {
-                expect(field.content).to.eql(content.en.translation.fields.townCity);
+            it('contains validation', () => {
+                expect(field.validations).to.not.be.empty;
             });
 
         });
@@ -160,8 +160,8 @@ describe('AppellantDetails.js', () => {
                 expect(field.name).to.equal('postCode');
             });
 
-            it('contains field content', () => {
-                expect(field.content).to.eql(content.en.translation.fields.postCode);
+            it('contains validation', () => {
+                expect(field.validations).to.not.be.empty;
             });
 
         });
@@ -176,8 +176,8 @@ describe('AppellantDetails.js', () => {
                 expect(field.name).to.equal('phoneNumber');
             });
 
-            it('contains field content', () => {
-                expect(field.content).to.eql(content.en.translation.fields.phoneNumber);
+            it('contains validation', () => {
+                expect(field.validations).to.not.be.empty;
             });
 
         });
@@ -192,8 +192,8 @@ describe('AppellantDetails.js', () => {
                 expect(field.name).to.equal('emailAddress');
             });
 
-            it('contains field content', () => {
-                expect(field.content).to.eql(content.en.translation.fields.emailAddress);
+            it('contains validation', () => {
+                expect(field.validations).to.not.be.empty;
             });
 
         });

--- a/test/unit/steps/identity/appointee-details/AppointeeDetails.test.js
+++ b/test/unit/steps/identity/appointee-details/AppointeeDetails.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { expect } = require('test/util/chai');
+const AppointeeDetails = require('steps/identity/appointee-details/AppointeeDetails');
+const content = require('steps/identity/appointee-details/content.json');
+const urls = require('urls');
+
+describe('AppointeeDetails.js', () => {
+
+    let appointeeDetailsClass;
+
+    beforeEach(() => {
+        appointeeDetailsClass = new AppointeeDetails();
+    });
+
+    after(() => {
+        appointeeDetailsClass = undefined;
+    });
+
+    describe('get url()', () => {
+
+        it('returns url /enter-appointee-details', () => {
+            expect(appointeeDetailsClass.url).to.equal(urls.identity.enterAppointeeDetails);
+        });
+
+    });
+
+    describe('get template()', () => {
+
+        it('returns template path identity/appointee-details/template', () => {
+            expect(appointeeDetailsClass.template).to.equal('identity/appointee-details/template');
+        });
+
+    });
+
+    describe('get i18NextContent()', () => {
+
+        it('returns the correct content for the page', () => {
+            expect(appointeeDetailsClass.i18NextContent).to.equal(content);
+        });
+
+    });
+
+});

--- a/test/unit/steps/identity/appointee/Appointee.test.js
+++ b/test/unit/steps/identity/appointee/Appointee.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { expect } = require('test/util/chai');
-const { stub, spy } = require('sinon');
+const { stub } = require('sinon');
 const Appointee = require('steps/identity/appointee/Appointee');
 const content = require('steps/identity/appointee/content.json');
 const urls = require('urls');

--- a/test/unit/steps/identity/appointee/Appointee.test.js
+++ b/test/unit/steps/identity/appointee/Appointee.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const { expect } = require('test/util/chai');
+const { stub } = require('sinon');
+const Appointee = require('steps/identity/appointee/Appointee');
+const content = require('steps/identity/appointee/content.json');
+const urls = require('urls');
+
+describe('Appointee.js', () => {
+
+    let appointeeClass;
+
+    beforeEach(() => {
+        appointeeClass = new Appointee();
+    });
+
+    after(() => {
+        appointeeClass = undefined;
+    });
+
+    describe('get url()', () => {
+
+        it('returns url /are-you-an-appointee', () => {
+            expect(appointeeClass.url).to.equal(urls.identity.areYouAnAppointee);
+        });
+
+    });
+
+    describe('get template()', () => {
+
+        it('returns template path identity/appointee/template', () => {
+            expect(appointeeClass.template).to.equal('identity/appointee/template');
+        });
+
+    });
+
+    describe('get i18NextContent()', () => {
+
+        it('returns the correct content for the page', () => {
+            expect(appointeeClass.i18NextContent).to.equal(content);
+        });
+
+    });
+
+    describe('get form()', () => {
+
+        let field;
+
+        beforeEach(() => {
+            field = appointeeClass.form.fields[0];
+        });
+
+        after(() => {
+            field = undefined;
+        });
+
+        it('contains the field name isappointee', () => {
+            expect(field.name).to.equal('isappointee');
+        });
+
+        it('contains field content', () => {
+            expect(field.content).to.eql(content.en.translation.fields.isappointee);
+        });
+
+    });
+
+    describe('next()', () => {
+
+        let redirector;
+
+        beforeEach(() => {
+            appointeeClass.fields = stub();
+            appointeeClass.fields.get = stub();
+        });
+
+        after(() => {
+            redirector = undefined;
+        });
+
+        it('returns the next step url /enter-appointee-details when isappointee value equals yes', () => {
+            appointeeClass.fields.get.withArgs('isappointee').returns({value: 'yes'});
+            redirector = {
+                nextStep: urls.identity.enterAppointeeDetails
+            };
+            appointeeClass.journey = {
+                AppointeeDetails: urls.identity.enterAppointeeDetails
+            };
+            expect(appointeeClass.next()).to.eql(redirector);
+        });
+
+
+        it('returns the next step url /enter-appellant-details when isappointee value equals no', () => {
+            appointeeClass.fields.get.withArgs('isappointee').returns({value: 'no'});
+            redirector = {
+                nextStep: urls.identity.enterAppellantDetails
+            };
+            appointeeClass.journey = {
+                AppellantDetails: urls.identity.enterAppellantDetails
+            };
+            expect(appointeeClass.next()).to.eql(redirector);
+        });
+
+    });
+
+});

--- a/test/unit/steps/identity/appointee/Appointee.test.js
+++ b/test/unit/steps/identity/appointee/Appointee.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { expect } = require('test/util/chai');
-const { stub } = require('sinon');
+const { stub, spy } = require('sinon');
 const Appointee = require('steps/identity/appointee/Appointee');
 const content = require('steps/identity/appointee/content.json');
 const urls = require('urls');
@@ -54,50 +54,49 @@ describe('Appointee.js', () => {
             field = undefined;
         });
 
-        it('contains the field name isappointee', () => {
-            expect(field.name).to.equal('isappointee');
+        it('contains the field name appointee', () => {
+            expect(field.name).to.equal('appointee');
         });
 
-        it('contains field content', () => {
-            expect(field.content).to.eql(content.en.translation.fields.isappointee);
+        it('contains validation', () => {
+            expect(field.validations).to.not.be.empty;
         });
 
     });
 
     describe('next()', () => {
 
-        let redirector;
-
         beforeEach(() => {
             appointeeClass.fields = stub();
-            appointeeClass.fields.get = stub();
-        });
-
-        after(() => {
-            redirector = undefined;
-        });
-
-        it('returns the next step url /enter-appointee-details when isappointee value equals yes', () => {
-            appointeeClass.fields.get.withArgs('isappointee').returns({value: 'yes'});
-            redirector = {
-                nextStep: urls.identity.enterAppointeeDetails
-            };
+            appointeeClass.fields.appointee = {};
             appointeeClass.journey = {
-                AppointeeDetails: urls.identity.enterAppointeeDetails
-            };
-            expect(appointeeClass.next()).to.eql(redirector);
-        });
-
-
-        it('returns the next step url /enter-appellant-details when isappointee value equals no', () => {
-            appointeeClass.fields.get.withArgs('isappointee').returns({value: 'no'});
-            redirector = {
-                nextStep: urls.identity.enterAppellantDetails
-            };
-            appointeeClass.journey = {
+                AppointeeDetails: urls.identity.enterAppointeeDetails,
                 AppellantDetails: urls.identity.enterAppellantDetails
             };
-            expect(appointeeClass.next()).to.eql(redirector);
+        });
+
+        it('returns branch object with condition property', () => {
+            appointeeClass.fields.appointee.value = 'yes';
+            const branches = appointeeClass.next().branches[0];
+            expect(branches).to.have.property('condition');
+        });
+
+        it('returns branch object where condition nextStep equals /enter-appointee-details', () => {
+            appointeeClass.fields.appointee.value = 'yes';
+            const redirector = {
+                nextStep: urls.identity.enterAppointeeDetails
+            };
+            const branches = appointeeClass.next().branches[0];
+            expect(branches.redirector).to.eql(redirector)
+        });
+
+        it('returns fallback object where nextStep equals /enter-appellant-details', () => {
+            appointeeClass.fields.appointee.value = 'no';
+            const redirector = {
+                nextStep: urls.identity.enterAppellantDetails
+            };
+            const fallback = appointeeClass.next().fallback;
+            expect(fallback).to.eql(redirector);
         });
 
     });

--- a/test/unit/steps/sms-notify/send-to-number/SendToNumber.test.js
+++ b/test/unit/steps/sms-notify/send-to-number/SendToNumber.test.js
@@ -4,6 +4,7 @@ const { expect } = require('test/util/chai');
 const { stub } = require('sinon');
 const SendToNumber = require('steps/sms-notify/send-to-number/SendToNumber');
 const content = require('steps/sms-notify/send-to-number/content.json');
+const urls = require('urls');
 
 describe('SendToNumber.js', () => {
 
@@ -59,6 +60,44 @@ describe('SendToNumber.js', () => {
 
         it('contains validation', () => {
             expect(field.validator).to.not.be.null;
+        });
+
+    });
+
+    describe('next()', () => {
+
+        beforeEach(() => {
+            sendToNumberClass.fields = stub();
+            sendToNumberClass.fields.useSameNumber = {};
+            sendToNumberClass.journey = {
+                SmsConfirmation: urls.smsNotify.smsConfirmation,
+                EnterMobile: urls.smsNotify.enterMobile
+            };
+        });
+
+        it('returns branch object with condition property', () => {
+            sendToNumberClass.fields.useSameNumber.value = 'yes';
+            const branches = sendToNumberClass.next().branches[0];
+            console.log(branches)
+            expect(branches).to.have.property('condition');
+        });
+
+        it('returns branch object where condition nextStep equals /sms-confirmation', () => {
+            sendToNumberClass.fields.useSameNumber.value = 'yes';
+            const redirector = {
+                nextStep: urls.smsNotify.smsConfirmation
+            };
+            const branches = sendToNumberClass.next().branches[0];
+            expect(branches.redirector).to.eql(redirector)
+        });
+
+        it('returns fallback object where nextStep equals /enter-mobile', () => {
+            sendToNumberClass.fields.useSameNumber.value = 'no';
+            const redirector = {
+                nextStep: urls.smsNotify.enterMobile
+            };
+            const fallback = sendToNumberClass.next().fallback;
+            expect(fallback).to.eql(redirector);
         });
 
     });


### PR DESCRIPTION
Add unit tests for the identity section of the form. Includes tests for the following pages:
 - Appellant-details
 - AppointeeDetails
 - Appointee
Also added branch testing for sendToNumber after the one per page update