### PR TITLE
Sms-confirmation bugfix

### DIFF
--- a/steps/sms-notify/sms-confirmation/template.html
+++ b/steps/sms-notify/sms-confirmation/template.html
@@ -17,7 +17,7 @@
     {{ header(content.title, size="large") }}
     <p>{{ content.mobileNumber }}
         <span class="bold-small">
-            {{ session.EnterMobile_mobileNumber if session.EnterMobile_mobileNumber else session.AppellantDetails_phoneNumber }}
+            {{ session.EnterMobile_mobileNumber if (session.EnterMobile_mobileNumber) and session.SendToNumber_useSameNumber == 'no' else session.AppellantDetails_phoneNumber }}
         </span>
     </p>
     <p>{{ content.firstMessage }}</p>


### PR DESCRIPTION
Fixed a bug where sms-confirmation page displayed the wrong number when the user changes steps using the back link.
Steps to recreate:
- User enters mobile number in appellant details
- User goes to send-to-number page after clicking sign-up. 
- User selects send to different number and enters new number.
- Sms-confirmation displays that new number.
- User clicks back to enter-mobile and then back again to send to number.
- User now click yes to send to the same number as the one entered in appellant details
- Sms-confirmation still displays the same number user entered in the enter-mobile step instead of the one entered in appellant details.

Fixed the bug by changing the logic in the html.
Now it only displays the enter-mobile step number when there enter-mobile field has a value AND when send-to-number step equals 'no'.