### PR TITLE
E2E tests for identify section

### DIFF
--- a/steps/identity/appellant-details/content.en.json
+++ b/steps/identity/appellant-details/content.en.json
@@ -1,5 +1,6 @@
 {
-  "title": "Enter your details",
+  "titleNoAppointee": "Enter your details",
+  "titleAppointee": "Enter appellants details",
   "subtitle": "We’ll use these to send you information about your appeal.",
   "fields": {
     "firstName": {

--- a/steps/identity/appellant-details/template.html
+++ b/steps/identity/appellant-details/template.html
@@ -10,7 +10,11 @@
 {% set feedbackLink="https://github.com/hmcts/one-per-page/issues/new" %}
 
 {% set title %}
-    {{ content.title | safe }}
+    {% if session.Appointee_appointee == 'yes' %}
+        {{ content.titleAppointee | safe }}
+    {% else %}
+        {{ content.titleNoAppointee | safe }}
+    {% endif %}
 {% endset %}
 
 {% block fields %}

--- a/steps/identity/appointee/Appointee.js
+++ b/steps/identity/appointee/Appointee.js
@@ -20,12 +20,7 @@ class Appointee extends Question {
     }
 
     next() {
-        const isAnAppointee = () => this.fields.appointee.value === answer.YES;
-
-        return branch(
-            goTo(this.journey.AppointeeDetails).if(isAnAppointee),
-            goTo(this.journey.AppellantDetails)
-        );
+        return goTo(this.journey.AppellantDetails)
     }
 }
 

--- a/test/e2e/scenarios/identity/appellantDetails.js
+++ b/test/e2e/scenarios/identity/appellantDetails.js
@@ -6,17 +6,15 @@ Feature('Appellant details form');
 
 Before((I) => {
     I.createTheSession();
-    I.amOnPage(urls.identity.areYouAnAppointee);
+    I.amOnPage(urls.identity.enterAppellantDetails);
 });
 
 After((I) => {
     I.endTheSession();
 });
 
-Scenario('User selects NO and completes the form', (I) => {
+Scenario('When I fill in the fields and click Continue, I am taken to the Text reminders page', (I) => {
 
-    I.selectAreYouAnAppointeeAndContinue(appointee.no);
-    I.seeCurrentUrlEquals(urls.identity.enterAppellantDetails);
     I.fillField('AppellantDetails_firstName', 'Harry');
     I.fillField('AppellantDetails_lastName', 'Potter');
     I.fillField('AppellantDetails_niNumber', 'AB123456C');
@@ -31,10 +29,8 @@ Scenario('User selects NO and completes the form', (I) => {
 
 });
 
-Scenario('User selects NO and does not complete the form', (I) => {
+Scenario('When I click Continue without filling in the fields I see errors', (I) => {
 
-    I.selectAreYouAnAppointeeAndContinue(appointee.no);
-    I.seeCurrentUrlEquals(urls.identity.enterAppellantDetails);
     I.click('Continue');
     I.see(appellant.firstName.error.required);
     I.see(appellant.lastName.error.required);
@@ -43,12 +39,5 @@ Scenario('User selects NO and does not complete the form', (I) => {
     I.see(appellant.addressLine2.error.required);
     I.see(appellant.townCity.error.required);
     I.see(appellant.postCode.error.required);
-
-});
-
-Scenario('User selects YES and views a placeholder', (I) => {
-
-    I.selectAreYouAnAppointeeAndContinue(appointee.yes);
-    I.seeCurrentUrlEquals(urls.identity.enterAppointeeDetails);
 
 });

--- a/test/e2e/scenarios/identity/appointee.js
+++ b/test/e2e/scenarios/identity/appointee.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const content = require('steps/identity/appellant-details/content.en.json');
+const urls = require('urls');
+
+Feature('Appellant details form');
+
+Before((I) => {
+    I.createTheSession();
+    I.amOnPage(urls.identity.areYouAnAppointee);
+});
+
+After((I) => {
+    I.endTheSession();
+});
+
+Scenario('When I select Yes, I am taken to the enter appellant details page', (I) => {
+
+    I.selectAreYouAnAppointeeAndContinue('Yes');
+    I.seeInCurrentUrl(urls.identity.enterAppellantDetails);
+    I.see(content.titleAppointee);
+
+});
+
+Scenario('When I select No, I am taken to the enter your details page', (I) => {
+
+    I.selectAreYouAnAppointeeAndContinue('No');
+    I.seeInCurrentUrl(urls.identity.enterAppellantDetails);
+    I.see(content.titleNoAppointee);
+
+});

--- a/test/unit/steps/identity/appointee/Appointee.test.js
+++ b/test/unit/steps/identity/appointee/Appointee.test.js
@@ -49,37 +49,14 @@ describe('Appointee.js', () => {
 
     describe('next()', () => {
 
-        beforeEach(() => {
-            appointeeClass.fields = stub();
-            appointeeClass.fields.appointee = {};
-            appointeeClass.journey = {
-                AppointeeDetails: urls.identity.enterAppointeeDetails,
-                AppellantDetails: urls.identity.enterAppellantDetails
-            };
-        });
-
-        it('returns branch object with condition property', () => {
-            appointeeClass.fields.appointee.value = 'yes';
-            const branches = appointeeClass.next().branches[0];
-            expect(branches).to.have.property('condition');
-        });
-
-        it('returns branch object where condition nextStep equals /enter-appointee-details', () => {
-            appointeeClass.fields.appointee.value = 'yes';
-            const redirector = {
-                nextStep: urls.identity.enterAppointeeDetails
-            };
-            const branches = appointeeClass.next().branches[0];
-            expect(branches.redirector).to.eql(redirector)
-        });
-
-        it('returns fallback object where nextStep equals /enter-appellant-details', () => {
-            appointeeClass.fields.appointee.value = 'no';
+        it('returns the next step url /enter-appellant-details', () => {
             const redirector = {
                 nextStep: urls.identity.enterAppellantDetails
             };
-            const fallback = appointeeClass.next().fallback;
-            expect(fallback).to.eql(redirector);
+            appointeeClass.journey = {
+                AppellantDetails: urls.identity.enterAppellantDetails
+            };
+            expect(appointeeClass.next()).to.eql(redirector);
         });
 
     });


### PR DESCRIPTION
- Add e2e tests for appointee and appellant details pages.
- Update flow so that when yes is selected for are you an appointee the user is taken to the enter-appellant-details page instead of enter-appointee-details page.
- Add logic in appellant details template to determine which title to use ('Enter your details' or 'Enter the appellants details') depending on the answer provided for are you an appointee.