### PR TITLE
Updated version of one-per-page to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@hmcts/look-and-feel": "^1.1.0",
     "@hmcts/nodejs-healthcheck": "^1.4.3",
-    "@hmcts/one-per-page": "^1.1.0",
+    "@hmcts/one-per-page": "^1.2.0",
     "accessible-autocomplete": "^1.6.1",
     "cross-env": "^5.0.5",
     "express": "^4.15.3",


### PR DESCRIPTION
Updating `one-per-page` to v1.2.0  https://github.com/hmcts/one-per-page/commit/ffe7d48ceb7775ea790702b9afac786af0a4fdf0