### PR TITLE
SMS-Confirmation remove change number link

### DIFF
--- a/steps/sms-notify/sms-confirmation/content.en.json
+++ b/steps/sms-notify/sms-confirmation/content.en.json
@@ -2,6 +2,5 @@
   "title": "You’re signed up for text message reminders",
   "mobileNumber": "Text messages will be sent to the following number: ",
   "firstMessage": "You’ll get your first message after you’ve submitted your appeal.",
-  "continue": "Continue",
-  "change": "Change number"
+  "continue": "Continue"
 }

--- a/steps/sms-notify/sms-confirmation/template.html
+++ b/steps/sms-notify/sms-confirmation/template.html
@@ -21,5 +21,4 @@
     </p>
     <p>{{ content.firstMessage }}</p>
     <p><a class="button" href="/representative">{{ content.continue }}</a></p>
-    <p><a class="link" href="/enter-mobile">{{ content.change }}</a></p>
 {% endblock %}

--- a/test/e2e/scenarios/sms-notify/smsConfirmation.js
+++ b/test/e2e/scenarios/sms-notify/smsConfirmation.js
@@ -23,14 +23,6 @@ Scenario('When I click Continue, I am taken to the Representative page', (I) => 
 
 });
 
-Scenario('When I click Change number, I am taken to the enter mobile page', (I) => {
-
-    I.goToSmsConfirmWithMobileNumber();
-    I.click(content.change);
-    I.seeInCurrentUrl(paths.smsNotify.enterMobile);
-
-});
-
 Scenario('When I enter a mobile number in appellant details and click use same number, I see the mobile number I provided for appellant details', (I) => {
 
     I.goToSmsConfirmWithMobileNumber();


### PR DESCRIPTION
Remove change number link from sms-confirmation template.
Remove the test that tests the redirection of the link.