### PR TITLE
SSCS-2187 County field validation

### DIFF
--- a/steps/representative/representative-details/RepresentativeDetails.js
+++ b/steps/representative/representative-details/RepresentativeDetails.js
@@ -56,8 +56,8 @@ class RepresentativeDetails extends Question {
             ),
 
             textField('county').joi(
-                fields.county.error.required,
-                Joi.string().regex(whitelist).required()
+                fields.county.error.invalid,
+                Joi.string().regex(whitelist).allow('')
             ),
 
             textField('postCode').joi(

--- a/steps/representative/representative-details/content.en.json
+++ b/steps/representative/representative-details/content.en.json
@@ -44,7 +44,7 @@
     "county": {
       "title": "County",
       "error": {
-        "required": "County not entered"
+        "invalid": "Invalid County entered"
       }
     },
     "postCode": {


### PR DESCRIPTION
Removed the required validation for the county field in representative details. This is because the field should be optional and so can be left blank.