### PR TITLE
overview url

### DIFF
--- a/landing-pages/start-an-appeal/template.html
+++ b/landing-pages/start-an-appeal/template.html
@@ -22,5 +22,5 @@
     <li>{{ whatYouNeedList.repDetails | safe }}</li>
 </ul>
 
-<a class="button" href="/">{{ start }}</a>
+<a class="button" href="/entry">{{ start }}</a>
 {%- endblock %}

--- a/paths.js
+++ b/paths.js
@@ -3,7 +3,7 @@ module.exports = {
     health:                             '/health',
 
     landingPages: {
-      overview:                         '/overview',
+      overview:                         '/',
       beforeYouAppeal:                  '/before-you-appeal',
       helpWithAppeal:                   '/help-with-appeal',
       startAnAppeal:                    '/start-an-appeal',
@@ -12,7 +12,7 @@ module.exports = {
 
     session: {
         createSession:                  '/create-session',
-        entry:                          '/',
+        entry:                          '/entry',
         exit:                           '/exit',
         sessions:                       '/sessions'
     },

--- a/test/e2e/page-objects/session/createSession.js
+++ b/test/e2e/page-objects/session/createSession.js
@@ -2,7 +2,7 @@ function createTheSession() {
 
     const I = this;
 
-    I.amOnPage('/', 'to create a session');
+    I.amOnPage('/entry', 'to create a session');
 }
 
 module.exports = { createTheSession };

--- a/test/e2e/scenarios/landing-pages/landingPages.js
+++ b/test/e2e/scenarios/landing-pages/landingPages.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const paths = require('paths');
+const overviewContent = require('landing-pages/overview/content.en.json');
+const beforeYouAppealContent = require('landing-pages/before-you-appeal/content.en.json');
+const helpWithAppealContent = require('landing-pages/help-with-appeal/content.en.json');
+const afterYouAppealContent = require('landing-pages/after-you-appeal/content.en.json');
+const startAnAppealContent = require('landing-pages/start-an-appeal/content.en.json');
+
+Feature('Landing Pages');
+
+Scenario('When I go to the Overview landing page, I see the page heading', (I) => {
+
+    I.amOnPage(paths.landingPages.overview);
+    I.see(overviewContent.heading);
+
+});
+
+Scenario('When I go to the Before you appeal landing page, I see the page heading', (I) => {
+
+    I.amOnPage(paths.landingPages.beforeYouAppeal);
+    I.see(beforeYouAppealContent.heading);
+
+});
+
+Scenario('When I go to the Help with appeal landing page, I see the page heading', (I) => {
+
+    I.amOnPage(paths.landingPages.helpWithAppeal);
+    I.see(helpWithAppealContent.heading);
+
+});
+
+Scenario('When I go to the after you appeal landing page, I see the page heading', (I) => {
+
+    I.amOnPage(paths.landingPages.afterYouAppeal);
+    I.see(afterYouAppealContent.heading);
+
+});
+
+Scenario('When I go to the start an appeal landing page, I see the page heading', (I) => {
+
+    I.amOnPage(paths.landingPages.startAnAppeal);
+    I.see(startAnAppealContent.heading);
+
+});

--- a/test/e2e/scenarios/landing-pages/landingPages.js
+++ b/test/e2e/scenarios/landing-pages/landingPages.js
@@ -44,7 +44,7 @@ Scenario('When I go to the start an appeal landing page, I see the page heading'
 
 });
 
-Scenario.only('When I go to the start an appeal landing page and click start appeal, I am taken to the benefits page', (I) => {
+Scenario('When I go to the start an appeal landing page and click start appeal, I am taken to the benefits page', (I) => {
 
     I.amOnPage(paths.landingPages.startAnAppeal);
     I.click('Start an appeal')

--- a/test/e2e/scenarios/landing-pages/landingPages.js
+++ b/test/e2e/scenarios/landing-pages/landingPages.js
@@ -43,3 +43,11 @@ Scenario('When I go to the start an appeal landing page, I see the page heading'
     I.see(startAnAppealContent.heading);
 
 });
+
+Scenario.only('When I go to the start an appeal landing page and click start appeal, I am taken to the benefits page', (I) => {
+
+    I.amOnPage(paths.landingPages.startAnAppeal);
+    I.click('Start an appeal')
+    I.seeInCurrentUrl(paths.start.benefitType);
+
+});

--- a/test/unit/steps/entry/Entry.test.js
+++ b/test/unit/steps/entry/Entry.test.js
@@ -18,7 +18,7 @@ describe('Entry.js', () => {
 
     describe('get url()', () => {
 
-        it('returns url /', () => {
+        it('returns url /entry', () => {
             expect(entryClass.url).to.equal(paths.session.entry);
         });
 


### PR DESCRIPTION
- Change `/overview` landing page url to `/`.
- Change the entry point url from `/` to `/entry`.
- Add e2e tests for the landing pages to test they go to the correct page.