### PR TITLE
Use webpack in all environments

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,8 +14,15 @@ const app = express();
 
 const protocol = config.node.protocol;
 const hostname = config.node.hostname;
+const port =     config.node.port;
 
-const baseUrl = `${protocol}://${hostname}`;
+let baseUrl;
+if(process.env.NODE_ENV === 'production') {
+    baseUrl = `${protocol}://${hostname}`;
+} else if (process.env.NODE_ENV === 'development') {
+    baseUrl = `${protocol}://${hostname}:${port}`;
+}
+
 console.log('SYA base Url : %s', baseUrl);
 
 lookAndFeel.configure(app, {
@@ -38,6 +45,12 @@ lookAndFeel.configure(app, {
                 to: 'images'
             }])
         ]
+    },
+    development: {
+        useWebpackDevMiddleware: true,
+        webpackDevMiddleware: {
+            // override default dev middleware settings
+        }
     }
 });
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "cross-env NODE_PATH=. node server.js",
     "start-dev": "cross-env NODE_PATH=. node-dev server.js",
+    "setup": "exit 0",
     "test": "cross-env NODE_PATH=. NODE_ENV=test nyc mocha 'test/unit/**/*.test.js'",
     "e2e": "cross-env NODE_PATH=. NODE_ENV=test codeceptjs run -c test/e2e/ --steps",
     "test-all": "cross-env NODE_PATH=. NODE_ENV=test yarn test && yarn e2e",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,8 +3,8 @@
 
 
 "@hmcts/look-and-feel@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@hmcts/look-and-feel/-/look-and-feel-1.1.1.tgz#6d68ba784a2db4373f34e28a6dffa5b2653fad4a"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@hmcts/look-and-feel/-/look-and-feel-1.2.0.tgz#4c4afbdecd645dbb4b6fcbb2e6c91d466d329a10"
   dependencies:
     babel-core "^6.26.0"
     babel-loader "^7.1.2"
@@ -61,8 +61,8 @@
     url-parse "^1.1.9"
 
 "@types/node@^7.0.18":
-  version "7.0.46"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.46.tgz#c3dedd25558c676b3d6303e51799abb9c3f8f314"
+  version "7.0.47"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.47.tgz#b8dd0fa81a19f919960a25fae646338e57d4998c"
 
 a-sync-waterfall@^1.0.0:
   version "1.0.0"
@@ -946,10 +946,10 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     electron-to-chromium "^1.2.7"
 
 browserslist@^2.1.2:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.8.0.tgz#27d64028130a2e8585ca96f7c3b7730eff4de493"
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.9.0.tgz#706aca15c53be15610f466e348cbfa0c00a6a379"
   dependencies:
-    caniuse-lite "^1.0.30000758"
+    caniuse-lite "^1.0.30000760"
     electron-to-chromium "^1.3.27"
 
 buffer-xor@^1.0.3:
@@ -1036,12 +1036,12 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000760"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000760.tgz#3ea29473eb78a6ccb09f2eb73ac9e1debfec528d"
+  version "1.0.30000764"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000764.tgz#d73ab11ae62f6a9e2f69867d6d9c23ae3f2e5d8d"
 
-caniuse-lite@^1.0.30000758:
-  version "1.0.30000760"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000760.tgz#ec720395742f1c7ec8947fd6dd2604e77a8f98ff"
+caniuse-lite@^1.0.30000760:
+  version "1.0.30000764"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000764.tgz#97ea7472f9d3e691eede34f21983cfc219ac7842"
 
 cardinal@^1.0.0:
   version "1.0.0"
@@ -2269,11 +2269,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
 fsevents@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.2.tgz#3282b713fb3ad80ede0e9fcf4611b5aa6fc033f4"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.3.tgz#11f82318f5fe7bb2cd22965a108e9306208216d8"
   dependencies:
     nan "^2.3.0"
-    node-pre-gyp "^0.6.36"
+    node-pre-gyp "^0.6.39"
 
 fstream-ignore@^1.0.5:
   version "1.0.5"
@@ -2425,8 +2425,8 @@ govuk-elements-sass@^3.1.1:
     govuk_frontend_toolkit "^7.1.0"
 
 govuk_frontend_toolkit@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/govuk_frontend_toolkit/-/govuk_frontend_toolkit-7.1.0.tgz#9c24ccbccd2b4df5ae9ecd3eeeac70b436597325"
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/govuk_frontend_toolkit/-/govuk_frontend_toolkit-7.2.0.tgz#5c006d83c3de33c7da49f720cadae83f58783158"
 
 govuk_template_jinja@^0.23.0:
   version "0.23.0"
@@ -3589,8 +3589,8 @@ mocha@^3.1.2, mocha@^3.5.3:
     supports-color "3.1.2"
 
 moment@^2.18.1:
-  version "2.19.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.1.tgz#56da1a2d1cbf01d38b7e1afc31c10bcfa1929167"
+  version "2.19.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.2.tgz#8a7f774c95a64550b4c7ebd496683908f9419dbe"
 
 moo-server@*, moo-server@1.3.x:
   version "1.3.0"
@@ -3737,7 +3737,7 @@ node-notifier@^4.0.2:
     shellwords "^0.1.0"
     which "^1.0.5"
 
-node-pre-gyp@^0.6.36:
+node-pre-gyp@^0.6.39:
   version "0.6.39"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
   dependencies:
@@ -3754,8 +3754,8 @@ node-pre-gyp@^0.6.36:
     tar-pack "^3.4.0"
 
 node-sass@^4.5.3:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.6.0.tgz#1a54f5f4502e3cde310a26d6346266fd667271d9"
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.6.1.tgz#9b331cf943ee5440f199e858941a90d13bc9bfc5"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"


### PR DESCRIPTION
* Added a port number to the baseUrl of look-and-feel configured to environment. When running locally we need to define a port number in order to view the assets/styles, this is done by webpack within look-and-feel. The opposite it true when running the application on CNP.
* Ensure we use the webpack dev middleware in a production environment for the interim until we have an asset management mechanism in place.
* The look-and-feel dependency has been upgraded from v1.1.1 to v1.2.0 and released.
* Added a yarn script "setup" that exits to indicate successful program termination. Note that look-and-feel has abstracted the generating of assets away, there's no need to even define this interface, I've added it for backward compatibility ensuring nothing breaks in the Jenkins pipeline.