### PR TITLE
SSCS-2339 lowercase postcode

### DIFF
--- a/valid-postcode-pages/routes.js
+++ b/valid-postcode-pages/routes.js
@@ -6,7 +6,7 @@ const invalidPostcodeContent = require('./postcode-invalid/content.en.json');
 const postcodeList = require('valid-postcode-pages/validPostcodeList');
 
 const postcodeIsValid = value => value.match(postCode);
-const postcodeInList = postcode => postcodeList.includes(postcode);
+const postcodeInList = postcode => postcodeList.includes(postcode.toUpperCase());
 const splitPostcode = postcode => postcode.replace(inwardPostcode, "").replace(/\s+/, "");
 
 const fields = {


### PR DESCRIPTION
- Fixed bug where user would enter a valid postcode that is on the list in lowercase letters. They would be taken to the download form page.
- This is because the postcode list is in uppercase letters
- Changed it so that the postcode is put i uppercase before checking whether it is on the list