### PR TITLE
Move dwp-issuing-office to after the postcode-check

### DIFF
--- a/steps/compliance/dwp-issuing-office/DWPIssuingOffice.js
+++ b/steps/compliance/dwp-issuing-office/DWPIssuingOffice.js
@@ -50,7 +50,7 @@ class DWPIssuingOffice extends Question {
 
     next() {
 
-        return goTo(this.journey.steps.PostcodeChecker);
+        return goTo(this.journey.steps.MRNDate);
     }
 }
 

--- a/steps/start/benefit-type/BenefitType.js
+++ b/steps/start/benefit-type/BenefitType.js
@@ -39,7 +39,7 @@ class BenefitType extends Question {
         const isPIPBenefitType = () => this.fields.benefitType.value === 'Personal Independence Payment (PIP)';
 
         return branch(
-            goTo(this.journey.steps.DWPIssuingOffice).if(isPIPBenefitType),
+            goTo(this.journey.steps.PostcodeChecker).if(isPIPBenefitType),
             goTo(this.journey.steps.AppointeeFormDownload)
         );
     }

--- a/steps/start/independence/Independence.js
+++ b/steps/start/independence/Independence.js
@@ -12,7 +12,7 @@ class Independence extends Question {
 
     next() {
 
-        return goTo(this.journey.steps.MRNDate);
+        return goTo(this.journey.steps.DWPIssuingOffice);
     }
 }
 

--- a/test/e2e/scenarios/compliance/dwpIssuingOffice.js
+++ b/test/e2e/scenarios/compliance/dwpIssuingOffice.js
@@ -17,7 +17,7 @@ After((I) => {
 Scenario('When I enter a valid issuing office, I am taken to the mrn date page', (I) => {
 
     I.enterDWPIssuingOfficeAndContinue('1');
-    I.seeInCurrentUrl(paths.start.postcodeCheck);
+    I.seeInCurrentUrl(paths.compliance.mrnDate);
 
 });
 

--- a/test/e2e/scenarios/cya/appellant/pip/does-not-attend-hearing.js
+++ b/test/e2e/scenarios/cya/appellant/pip/does-not-attend-hearing.js
@@ -89,9 +89,9 @@ Scenario('Appellant defines an optional phone number, but doesn\'t sign up for t
 const IenterDetailsFromStartToNINO = (I) => {
 
     I.enterBenefitTypeAndContinue('PIP');
-    I.enterDWPIssuingOfficeAndContinue('1');
     I.enterPostcodeAndContinue('WV11 2HE');
     I.continueFromIndependance();
+    I.enterDWPIssuingOfficeAndContinue('1');
     I.enterAnMRNDateAndContinue(oneMonthAgo);
     I.selectAreYouAnAppointeeAndContinue('No, I’m appealing for myself');
     I.enterAppellantNameAndContinue('Mr','Harry','Potter');

--- a/test/e2e/scenarios/start/benefitType.js
+++ b/test/e2e/scenarios/start/benefitType.js
@@ -12,10 +12,10 @@ After((I) => {
     I.endTheSession();
 });
 
-Scenario('When I enter PIP, I am taken to the DWP Issuing office page', (I) => {
+Scenario('When I enter PIP, I am taken to the postcode-check page', (I) => {
 
     I.enterBenefitTypeAndContinue('Personal Independence Payment (PIP)');
-    I.seeInCurrentUrl(paths.compliance.dwpIssuingOffice);
+    I.seeInCurrentUrl(paths.start.postcodeCheck);
 
 });
 

--- a/test/unit/steps/compliance/dwp-issuing-office/DWPIssuingOffice.test.js
+++ b/test/unit/steps/compliance/dwp-issuing-office/DWPIssuingOffice.test.js
@@ -14,7 +14,7 @@ describe('DWPIssuingOffice.js', () => {
         dWPIssuingOffice = new DWPIssuingOffice({
             journey: {
                 steps: {
-                    PostcodeChecker: paths.start.postcodeCheck
+                    MRNDate: paths.compliance.mrnDate
                 }
             }
         });
@@ -57,8 +57,8 @@ describe('DWPIssuingOffice.js', () => {
 
     describe('next()', () => {
 
-        it('returns the next step path /postcode-check', () => {
-            expect(dWPIssuingOffice.next()).to.eql({ nextStep: paths.start.postcodeCheck });
+        it('returns the next step path /mrn-date', () => {
+            expect(dWPIssuingOffice.next()).to.eql({ nextStep: paths.compliance.mrnDate });
         });
 
     });

--- a/test/unit/steps/start/BenefitType.test.js
+++ b/test/unit/steps/start/BenefitType.test.js
@@ -14,7 +14,7 @@ describe('BenefitType.js', () => {
             journey: {
                 steps: {
                     AppointeeFormDownload: paths.identity.downloadAppointeeForm,
-                    DWPIssuingOffice: paths.compliance.dwpIssuingOffice
+                    PostcodeChecker: paths.start.postcodeCheck
                 }
             }
         });
@@ -54,9 +54,9 @@ describe('BenefitType.js', () => {
             expect(benefitType.next().step).to.eql(paths.identity.downloadAppointeeForm);
         });
 
-        it('returns the next step path /dwp-issuing-office with benefit type value is PIP', () => {
+        it('returns the next step path /postcode-check with benefit type value is PIP', () => {
             benefitType.fields.benefitType.value = 'Personal Independence Payment (PIP)';
-            expect(benefitType.next().step).to.eql(paths.compliance.dwpIssuingOffice);
+            expect(benefitType.next().step).to.eql(paths.start.postcodeCheck);
         });
 
     });

--- a/test/unit/steps/start/Independence.test.js
+++ b/test/unit/steps/start/Independence.test.js
@@ -13,7 +13,7 @@ describe('Independence.js', () => {
         independence = new Independence({
             journey: {
                 steps: {
-                    MRNDate: paths.compliance.mrnDate
+                    DWPIssuingOffice: paths.compliance.dwpIssuingOffice
                 }
             }
         });
@@ -31,7 +31,7 @@ describe('Independence.js', () => {
     describe('next()', () => {
 
         it('returns the next step path /mrn-date', () => {
-            expect(independence.next().step).to.eql(paths.compliance.mrnDate);
+            expect(independence.next().step).to.eql(paths.compliance.dwpIssuingOffice);
         });
 
 


### PR DESCRIPTION
- Moved DWP-issuing-office to be after the postcode-check
- Changed the DWPIssuingOffice next() function to go to `mrn-date`
- Changed the BenefitType next() function to go to `postcode-check`
- Changed the Independence next() function to go to `dwp-issuing-office`
- Changed the e2e and unit tests