### PR TITLE
SSCS-2426 Improve nino regex

### DIFF
--- a/test/unit/utils/regex.test.js
+++ b/test/unit/utils/regex.test.js
@@ -97,8 +97,122 @@ describe('validating a National Insurance number', () => {
         expect(niNumberValidator).to.not.equal(null);
     });
 
-    it("should not validate against a valid National Insurance number", () => {
-        number = 'AB1234';
+    it("should not validate against a National Insurance number with BG prefix", () => {
+        number = 'BG123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number with GB prefix", () => {
+        number = 'GB123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number with KN prefix", () => {
+        number = 'KN123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number with NK prefix", () => {
+        number = 'NK123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number with NT prefix", () => {
+        number = 'NT123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number with TN prefix", () => {
+        number = 'TN123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number with ZZ prefix", () => {
+        number = 'ZZ123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number when O is the second letter of prefix", () => {
+        number = 'SO123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number when D is the first letter of prefix", () => {
+        number = 'DA123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number when D is the second letter of prefix", () => {
+        number = 'AD123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number when F is the first letter of prefix", () => {
+        number = 'FA123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number when F is the second letter of prefix", () => {
+        number = 'AF123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number when I is the first letter of prefix", () => {
+        number = 'IA123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number when I is the second letter of prefix", () => {
+        number = 'AI123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number when Q is the first letter of prefix", () => {
+        number = 'QA123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number when Q is the second letter of prefix", () => {
+        number = 'AQ123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number when U is the first letter of prefix", () => {
+        number = 'UA123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number when U is the second letter of prefix", () => {
+        number = 'AU123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number when V is the first letter of prefix", () => {
+        number = 'VA123456A';
+        niNumberValidator = number.match(niNumber);
+        expect(niNumberValidator).to.equal(null);
+    });
+
+    it("should not validate against a National Insurance number when V is the second letter of prefix", () => {
+        number = 'AV123456A';
         niNumberValidator = number.match(niNumber);
         expect(niNumberValidator).to.equal(null);
     });

--- a/utils/regex.js
+++ b/utils/regex.js
@@ -1,13 +1,13 @@
-const postCode  = /^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z]))))\s?[0-9][A-Za-z]{2})$/;
+const postCode = /^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z]))))\s?[0-9][A-Za-z]{2})$/;
 const inwardPostcode = /\d[a-z]{2}$/i;
-const niNumber  = /^\s*[a-zA-Z]{1}\s*[a-zA-Z]{1}\s*(?:\s*\d\s*){6}[a-zA-Z]{1}\s*$/;
+const niNumber = /^(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)\s?(?:[A-CEGHJ-PR-TW-Z]\s?[A-CEGHJ-NPR-TW-Z])\s?(?:\d\s?){6}([A-D]|\s)\s?$/i;
 const title = /^[a-zA-Z /&]{2,}$/;
 const firstName = /^[a-zA-z]+([-][a-zA-Z]+)*$/;
-const lastName  = /^[a-zA-z]+([ '-][a-zA-Z]+)*$/;
+const lastName = /^[a-zA-z]+([ '-][a-zA-Z]+)*$/;
 const whitelist = /^[a-zA-Z0-9 .",'?!()£:-]{2,}$/;
-const numbers  = /^[0-9]+$/;
-const phoneNumber  = /^[0-9\-\+ ]{10,17}$/;
-const benefitType   = /^[a-zA-Z ()]+$/;
+const numbers = /^[0-9]+$/;
+const phoneNumber = /^[0-9\-\+ ]{10,17}$/;
+const benefitType = /^[a-zA-Z ()]+$/;
 const mobileNumber = /^(\+44\s?7\d{3}|\(?07\d{3}\)?)\s?\d{3}\s?\d{3}$/;
 const internationalMobileNumber = /^(?:00|\+|07|\(\d+\))[0-9\s.\/-]{7,}$/;
 


### PR DESCRIPTION
- Changed the nino regex so that it matches this manual https://www.gov.uk/hmrc-internal-manuals/national-insurance-manual/nim39110 while still allowing spaces and lowercase letters.
- Write unit tests to test the regex matches the manual requirements