### PR TITLE
SSCS-2455Make carers allowance form SSCS1

### DIFF
--- a/steps/identity/appointee-form-download/AppointeeFormDownload.js
+++ b/steps/identity/appointee-form-download/AppointeeFormDownload.js
@@ -23,7 +23,7 @@ class AppointeeFormDownload extends Question {
         const benefitType = this.fields.benefitType.value;
         let formDownload = {};
 
-        if (benefitType === benefitTypes.carersAllowance || benefitType === benefitTypes.childBenefit) {
+        if (benefitType === benefitTypes.childBenefit) {
             formDownload.link = urls.formDownload.sscs5;
             formDownload.type = 'SSCS5';
         } else {

--- a/test/e2e/scenarios/identity/AppointeeFormDownload.js
+++ b/test/e2e/scenarios/identity/AppointeeFormDownload.js
@@ -19,13 +19,6 @@ Scenario('I see SSCS1 content when I select any Benefit type other than Carer’
 
 });
 
-Scenario('I see SSCS5 content when I select Carer’s Allowance as a benefit type', (I) => {
-
-    I.enterBenefitTypeAndContinue(benefitTypes.carersAllowance);
-    I.see('Download and fill out a SSCS5 form to appeal a Carer’s Allowance benefit decision.');
-
-});
-
 Scenario('I see SSCS5 content when I select Child Benefit as a benefit type', (I) => {
 
     I.enterBenefitTypeAndContinue(benefitTypes.childBenefit);

--- a/test/unit/steps/identity/appointee-form-download/AppointeeFormDownload.test.js
+++ b/test/unit/steps/identity/appointee-form-download/AppointeeFormDownload.test.js
@@ -42,19 +42,9 @@ describe('AppointeeFormDownload.js', () => {
 
     describe('get getFormLink()', () => {
 
-        it('returns SSCS5 form link when Benefit type is Carer\'s Allowance', () => {
-            appointeeFormDownload.fields.benefitType.value = benefitTypes.carersAllowance;
-            expect(appointeeFormDownload.formDownload.link).to.equal(urls.formDownload.sscs5);
-        });
-
         it('returns SSCS5 form link when Benefit type is Child Benefit', () => {
             appointeeFormDownload.fields.benefitType.value = benefitTypes.childBenefit;
             expect(appointeeFormDownload.formDownload.link).to.equal(urls.formDownload.sscs5);
-        });
-
-        it('returns SSCS5 form type when Benefit type is Carer\'s Allowance', () => {
-            appointeeFormDownload.fields.benefitType.value = benefitTypes.carersAllowance;
-            expect(appointeeFormDownload.formDownload.type).to.equal('SSCS5');
         });
 
         it('returns SSCS5 form type when Benefit type is Child Benefit', () => {
@@ -62,12 +52,12 @@ describe('AppointeeFormDownload.js', () => {
             expect(appointeeFormDownload.formDownload.type).to.equal('SSCS5');
         });
 
-        it('returns SSCS1 form link when Benefit type is not Carer\'s Allowance or Child Benefit', () => {
+        it('returns SSCS1 form link when Benefit type is not Child Benefit', () => {
             appointeeFormDownload.fields.benefitType.value = benefitTypes.socialFund;
             expect(appointeeFormDownload.formDownload.link).to.equal(urls.formDownload.sscs1);
         });
 
-        it('returns SSCS1 form type when Benefit type is not Carer\'s Allowance or Child Benefit', () => {
+        it('returns SSCS1 form type when Benefit type is not Child Benefit', () => {
             appointeeFormDownload.fields.benefitType.value = benefitTypes.socialFund;
             expect(appointeeFormDownload.formDownload.type).to.equal('SSCS1');
         });


### PR DESCRIPTION
- For the download form page, make the Carers Allowance benefit type get SSCS1 form content and link instead of SSCS5.
- Change the e2e and unit tests