### PR TITLE
SSCS-2233 betabanner

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,7 +56,7 @@ lookAndFeel.configure(app, {
     nunjucks: {
         globals: {
             phase: 'BETA',
-            html: `${content.phaseBanner.newService}
+            banner: `${content.phaseBanner.newService}
                     <a href="${urls.phaseBanner}" target="_blank">${content.phaseBanner.reportProblem}</a>
                     ${content.phaseBanner.improve}`,
             isArray(value) {

--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ const errorPages = require('error-pages/routes');
 const policyPages = require('policy-pages/routes');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const content = require('content.en.json');
+const urls = require('urls');
 
 const app = express();
 
@@ -55,7 +56,9 @@ lookAndFeel.configure(app, {
     nunjucks: {
         globals: {
             phase: 'BETA',
-            feedbackLink: `mailto:benefitappeal_helpdesk@digital.justice.gov.uk?subject=${content.email.subject}&body=${content.email.body}`,
+            html: `${content.phaseBanner.newService}
+                    <a href="${urls.phaseBanner}" target="_blank">${content.phaseBanner.reportProblem}</a>
+                    ${content.phaseBanner.improve}`,
             isArray(value) {
                 return Array.isArray(value);
             }

--- a/content.en.json
+++ b/content.en.json
@@ -1,6 +1,7 @@
 {
-  "email": {
-    "subject": "Report a problem",
-    "body": "Don’t include personal or financial information like evidence, your National Insurance number or credit card details."
+  "phaseBanner": {
+    "newService": "This is a new service. ",
+    "reportProblem": "Report a problem",
+    "improve": " and help improve it for others."
   }
 }

--- a/error-pages/404/template.html
+++ b/error-pages/404/template.html
@@ -8,7 +8,9 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-    {{ phaseBanner(phase, feedbackLink) }}
+    {% call phaseBanner(phase) %}
+        {{ banner | safe }}
+    {% endcall %}
 {% endblock %}
 
 {% block two_thirds %}

--- a/error-pages/500/template.html
+++ b/error-pages/500/template.html
@@ -8,7 +8,9 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-    {{ phaseBanner(phase, feedbackLink) }}
+    {% call phaseBanner(phase) %}
+        {{ banner | safe }}
+    {% endcall %}
 {% endblock %}
 
 {% block two_thirds %}

--- a/error-pages/timed-out/template.html
+++ b/error-pages/timed-out/template.html
@@ -8,7 +8,9 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-    {{ phaseBanner(phase, feedbackLink) }}
+    {% call phaseBanner(phase) %}
+        {{ banner | safe }}
+    {% endcall %}
 {% endblock %}
 
 {% block two_thirds %}

--- a/landing-pages/landing-page-template.html
+++ b/landing-pages/landing-page-template.html
@@ -4,7 +4,7 @@
 {% from "look-and-feel/components/phase_banner.njk" import phaseBanner %}
 
 {% block breadcrumbs %}
-    {{ phaseBanner(phase, feedbackLink) }}
+    {{ phaseBanner(phase, feedbackLink, html) }}
     <div class="breadcrumbs">
         <ol>
             <li><a href="https://www.gov.uk">{{ breadcrumbs.home }}</a></li>

--- a/landing-pages/landing-page-template.html
+++ b/landing-pages/landing-page-template.html
@@ -4,7 +4,9 @@
 {% from "look-and-feel/components/phase_banner.njk" import phaseBanner %}
 
 {% block breadcrumbs %}
-    {{ phaseBanner(phase, feedbackLink, html) }}
+    {% call phaseBanner(phase) %}
+        {{ banner | safe }}
+    {% endcall %}
     <div class="breadcrumbs">
         <ol>
             <li><a href="https://www.gov.uk">{{ breadcrumbs.home }}</a></li>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "health-check": "echo 'not implemented yet'"
   },
   "dependencies": {
-    "@hmcts/look-and-feel": "1.3.0",
+    "@hmcts/look-and-feel": "^1.3.0",
     "@hmcts/nodejs-healthcheck": "^1.4.3",
     "@hmcts/one-per-page": "^2.0.0-3",
     "accessible-autocomplete": "^1.6.1",

--- a/policy-pages/cookie-policy/template.html
+++ b/policy-pages/cookie-policy/template.html
@@ -6,7 +6,9 @@
 {% set title = cookies.title%}
 
 {% block breadcrumbs %}
-    {{ phaseBanner(phase, feedbackLink) }}
+    {% call phaseBanner(phase) %}
+        {{ banner | safe }}
+    {% endcall %}
 {% endblock %}
 
 {% block two_thirds %}

--- a/policy-pages/terms-and-conditions/template.html
+++ b/policy-pages/terms-and-conditions/template.html
@@ -2,12 +2,6 @@
 {% extends "look-and-feel/layouts/two_thirds.html" %}
 {% from "look-and-feel/components/phase_banner.njk" import phaseBanner %}
 
-{% block breadcrumbs %}
-    {{ phaseBanner(phase, feedbackLink) }}
-    <a class="link-back" href="#" onclick="history.go(-1); return false;">Back</a>
-{% endblock %}
-
-
 {% block two_thirds %}
     {% set title %}
         {{ title | safe }}

--- a/steps/start/invalid-postcode/template.html
+++ b/steps/start/invalid-postcode/template.html
@@ -5,11 +5,6 @@
 
 {% set title = content.title %}
 
-{% block breadcrumbs %}
-{{ phaseBanner(phase, feedbackLink) }}
-<a class="link-back" href="#" onclick="history.go(-1); return false;">Back</a>
-{% endblock %}
-
 {% block two_thirds %}
 
 {{ header(title, size='large') }}

--- a/urls.js
+++ b/urls.js
@@ -1,5 +1,6 @@
 module.exports = {
 
+    phaseBanner: 'https://www.smartsurvey.co.uk/s/QQQ7L/',
     surveyLink: 'https://www.smartsurvey.co.uk/s/4XAAH/',
     formDownload: {
         sscs1: 'http://formfinder.hmctsformfinder.justice.gov.uk/sscs1-eng.pdf',

--- a/views/components/globals.html
+++ b/views/components/globals.html
@@ -1,3 +1,12 @@
+{% from "look-and-feel/components/phase_banner.njk" import phaseBanner %}
+
+{% block breadcrumbs %}
+    {% call phaseBanner(phase) %}
+        {{ banner | safe }}
+    {% endcall %}
+    <a class="link-back" href="#" onclick="history.go(-1); return false;">Back</a>
+{% endblock %}
+
 {% block head -%}
     <link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
 {% endblock %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@hmcts/look-and-feel@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@hmcts/look-and-feel/-/look-and-feel-1.3.0.tgz#39bf8b3a700c8137cb3187ad4d7b3556652cb8d6"
+"@hmcts/look-and-feel@^1.3.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@hmcts/look-and-feel/-/look-and-feel-1.6.0.tgz#9742019da694e6f4a47f4c00ae5d41c74be60f6a"
   dependencies:
     babel-core "^6.26.0"
     babel-loader "^7.1.2"


### PR DESCRIPTION
- updated look and feel
- In app.js, created njk global called banner which has the text and link for the phase banner.
- Added phasebanner content to the global content file
- In globals.html, added breadcrumbs block calling the new phasebanner and overwriting it with our banner global.
- Called the phasbanner function in various html files that do not need the backLink as this is defaulted in the globals html file
- Added feedback link to urls.js