### PR TITLE
Feature/sscs 2421 sign and submit

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -6,6 +6,10 @@ p.contact-us::first-line {
   font-weight: bold;
 }
 
+label.form-label[for="signer"] {
+  font-weight: bold;
+}
+
 .after-form {
   padding-top: 1.5em;
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "health-check": "echo 'not implemented yet'"
   },
   "dependencies": {
-    "@hmcts/look-and-feel": "^1.3.0",
+    "@hmcts/look-and-feel": "^1.7.0",
     "@hmcts/nodejs-healthcheck": "^1.4.3",
     "@hmcts/one-per-page": "^2.0.0-3",
     "accessible-autocomplete": "^1.6.1",

--- a/steps/check-your-appeal/CheckYourAppeal.js
+++ b/steps/check-your-appeal/CheckYourAppeal.js
@@ -25,24 +25,6 @@ class CheckYourAppeal extends CYA {
         return paths.checkYourAppeal
     }
 
-    get debugObj() {
-        console.log(`Appeal:`);
-        console.log(`\t incomplete: ${this.incomplete}`);
-        console.log(`\t complete: ${this.complete}`);
-        console.log(`\nSections:`);
-        this._sections.forEach( section => {
-                console.log(`\tsection.id: ${section.id}`);
-                console.log(`\t\t incomplete: ${section.incomplete}`);
-                console.log(`\t\t answers:`);
-                section.answers.forEach(answer => {
-                        console.log(`\t\t\t id: ${answer.id}`);
-                        console.log(`\t\t\t\t complete: ${answer.complete}`);
-                        console.log(`\t\t\t\t answer: ${answer.answer}`);
-                    })
-            });
-        return true
-        }
-
     sendToAPI() {
         // Temporary
         console.log(JSON.stringify(this.journey.values, null, 2));

--- a/steps/check-your-appeal/CheckYourAppeal.js
+++ b/steps/check-your-appeal/CheckYourAppeal.js
@@ -28,7 +28,7 @@ class CheckYourAppeal extends CYA {
 
     sendToAPI() {
         // Temporary
-        console.log(JSON.stringify(this.journey.values, null, '\t'));
+        console.log(JSON.stringify(this.journey.values, null, 2));
         console.log(this.journey.settings.apiUrl);
         return request.post(this.journey.settings.apiUrl).send(this.journey.values);
     }

--- a/steps/check-your-appeal/CheckYourAppeal.js
+++ b/steps/check-your-appeal/CheckYourAppeal.js
@@ -25,6 +25,10 @@ class CheckYourAppeal extends CYA {
         return paths.checkYourAppeal
     }
 
+    get termsAndConditionPath() {
+        return paths.policy.termsAndConditions
+    }
+
     sendToAPI() {
         // Temporary
         console.log(JSON.stringify(this.journey.values, null, 2));

--- a/steps/check-your-appeal/CheckYourAppeal.js
+++ b/steps/check-your-appeal/CheckYourAppeal.js
@@ -21,8 +21,25 @@ class CheckYourAppeal extends CYA {
         this.sendToAPI = this.sendToAPI.bind(this);
     }
 
-    static get path() {
+    get debugObj() {
+        console.log(`Appeal:`);
+        console.log(`\t incomplete: ${this.incomplete}`);
+        console.log(`\t complete: ${this.complete}`);
+        console.log(`\nSections:`);
+        this._sections.forEach( section => {
+            console.log(`\tsection.id: ${section.id}`);
+            console.log(`\t\t incomplete: ${section.incomplete}`);
+            console.log(`\t\t answers:`);
+            section.answers.forEach(answer => {
+                console.log(`\t\t\t id: ${answer.id}`);
+                console.log(`\t\t\t\t complete: ${answer.complete}`);
+                console.log(`\t\t\t\t answer: ${answer.answer}`);
+            })
+        });
+        return true
+    }
 
+    static get path() {
         return paths.checkYourAppeal
     }
 
@@ -58,6 +75,15 @@ class CheckYourAppeal extends CYA {
         );
     }
 
+    // answers() {
+    //
+    //     return answer(this, {
+    //         question: "Check Your Appeal Signer",
+    //         section: sections.checkYourAppeal,
+    //         answer: true
+    //     });
+    // }
+
     values() {
 
         return {
@@ -68,7 +94,6 @@ class CheckYourAppeal extends CYA {
     }
 
     next() {
-
         return action(this.sendToAPI)
             .then(goTo(this.journey.steps.Confirmation))
     }

--- a/steps/check-your-appeal/CheckYourAppeal.js
+++ b/steps/check-your-appeal/CheckYourAppeal.js
@@ -21,24 +21,6 @@ class CheckYourAppeal extends CYA {
         this.sendToAPI = this.sendToAPI.bind(this);
     }
 
-    get debugObj() {
-        console.log(`Appeal:`);
-        console.log(`\t incomplete: ${this.incomplete}`);
-        console.log(`\t complete: ${this.complete}`);
-        console.log(`\nSections:`);
-        this._sections.forEach( section => {
-            console.log(`\tsection.id: ${section.id}`);
-            console.log(`\t\t incomplete: ${section.incomplete}`);
-            console.log(`\t\t answers:`);
-            section.answers.forEach(answer => {
-                console.log(`\t\t\t id: ${answer.id}`);
-                console.log(`\t\t\t\t complete: ${answer.complete}`);
-                console.log(`\t\t\t\t answer: ${answer.answer}`);
-            })
-        });
-        return true
-    }
-
     static get path() {
         return paths.checkYourAppeal
     }
@@ -74,15 +56,6 @@ class CheckYourAppeal extends CYA {
                 Joi.string().regex(whitelist))
         );
     }
-
-    // answers() {
-    //
-    //     return answer(this, {
-    //         question: "Check Your Appeal Signer",
-    //         section: sections.checkYourAppeal,
-    //         answer: true
-    //     });
-    // }
 
     values() {
 

--- a/steps/check-your-appeal/CheckYourAppeal.js
+++ b/steps/check-your-appeal/CheckYourAppeal.js
@@ -22,14 +22,17 @@ class CheckYourAppeal extends CYA {
     }
 
     static get path() {
+
         return paths.checkYourAppeal
     }
 
     get termsAndConditionPath() {
+
         return paths.policy.termsAndConditions
     }
 
     sendToAPI() {
+
         // Temporary
         console.log(JSON.stringify(this.journey.values, null, 2));
         console.log(this.journey.settings.apiUrl);
@@ -71,6 +74,7 @@ class CheckYourAppeal extends CYA {
     }
 
     next() {
+
         return action(this.sendToAPI)
             .then(goTo(this.journey.steps.Confirmation))
     }

--- a/steps/check-your-appeal/CheckYourAppeal.js
+++ b/steps/check-your-appeal/CheckYourAppeal.js
@@ -11,7 +11,7 @@ const request = require('superagent');
 const paths = require('paths');
 const {form, textField} = require('@hmcts/one-per-page/forms');
 const Joi = require('joi');
-const { whitelist } = require('utils/regex');
+const { lastName } = require('utils/regex');
 
 class CheckYourAppeal extends CYA {
 
@@ -53,7 +53,7 @@ class CheckYourAppeal extends CYA {
 
             textField('signer').joi(
                 this.content.fields.signer.error.required,
-                Joi.string().regex(whitelist))
+                Joi.string().regex(lastName))
         );
     }
 

--- a/steps/check-your-appeal/CheckYourAppeal.js
+++ b/steps/check-your-appeal/CheckYourAppeal.js
@@ -25,6 +25,24 @@ class CheckYourAppeal extends CYA {
         return paths.checkYourAppeal
     }
 
+    get debugObj() {
+        console.log(`Appeal:`);
+        console.log(`\t incomplete: ${this.incomplete}`);
+        console.log(`\t complete: ${this.complete}`);
+        console.log(`\nSections:`);
+        this._sections.forEach( section => {
+                console.log(`\tsection.id: ${section.id}`);
+                console.log(`\t\t incomplete: ${section.incomplete}`);
+                console.log(`\t\t answers:`);
+                section.answers.forEach(answer => {
+                        console.log(`\t\t\t id: ${answer.id}`);
+                        console.log(`\t\t\t\t complete: ${answer.complete}`);
+                        console.log(`\t\t\t\t answer: ${answer.answer}`);
+                    })
+            });
+        return true
+        }
+
     sendToAPI() {
         // Temporary
         console.log(JSON.stringify(this.journey.values, null, 2));

--- a/steps/check-your-appeal/CheckYourAppeal.js
+++ b/steps/check-your-appeal/CheckYourAppeal.js
@@ -58,11 +58,6 @@ class CheckYourAppeal extends CYA {
         );
     }
 
-    answers() {
-
-        return [];
-    }
-
     values() {
 
         return {

--- a/steps/check-your-appeal/CheckYourAppeal.js
+++ b/steps/check-your-appeal/CheckYourAppeal.js
@@ -24,11 +24,9 @@ class CheckYourAppeal extends CYA {
     }
 
     sendToAPI() {
-
         // Temporary
-        console.log(JSON.stringify(this.journey.values));
+        console.log(JSON.stringify(this.journey.values, null, '\t'));
         console.log(this.journey.settings.apiUrl);
-
         return request.post(this.journey.settings.apiUrl).send(this.journey.values);
     }
 

--- a/steps/check-your-appeal/CheckYourAppeal.js
+++ b/steps/check-your-appeal/CheckYourAppeal.js
@@ -9,6 +9,9 @@ const { goTo, action } = require('@hmcts/one-per-page/flow');
 const sections = require('steps/check-your-appeal/sections');
 const request = require('superagent');
 const paths = require('paths');
+const {form, textField} = require('@hmcts/one-per-page/forms');
+const Joi = require('joi');
+const { whitelist } = require('utils/regex');
 
 class CheckYourAppeal extends CYA {
 
@@ -43,6 +46,30 @@ class CheckYourAppeal extends CYA {
             section(sections.theHearing,            { title: this.content.hearing.theHearing }),
             section(sections.hearingArrangements,   { title: this.content.hearing.arrangements })
         ];
+    }
+
+    get form() {
+
+        return form(
+
+            textField('signer').joi(
+                this.content.fields.signer.error.required,
+                Joi.string().regex(whitelist))
+        );
+    }
+
+    answers() {
+
+        return [];
+    }
+
+    values() {
+
+        return {
+            signAndSubmit: {
+                signer: this.fields.signer.value
+            }
+        };
     }
 
     next() {

--- a/steps/check-your-appeal/content.en.json
+++ b/steps/check-your-appeal/content.en.json
@@ -18,5 +18,17 @@
     "mobile": "Mobile"
   },
   "representative": "Representative",
-  "reasonsForAppealing": "Reasons for appealing"
+  "reasonsForAppealing": "Reasons for appealing",
+  "fields": {
+    "signer": {
+      "error": {
+        "required": "Enter a Name"
+      },
+      "label": "Enter your name",
+      "hint": "This should be the person who is named on the appeal"
+    }
+  },
+  "submitButton": {
+    "value": "Submit your appeal"
+  }
 }

--- a/steps/check-your-appeal/content.en.json
+++ b/steps/check-your-appeal/content.en.json
@@ -19,6 +19,10 @@
   },
   "representative": "Representative",
   "reasonsForAppealing": "Reasons for appealing",
+  "header": "Sign and submit",
+  "information": "The information I have provided in this appeal is accurate, to the best of my knowledge.",
+  "permission": "I give permission for you to correspond with my named representative about my appeal.",
+  "agree": "I agree to the <a href='{{ termsAndConditionPath }}'>terms and conditions</a> of using the ‘Appeal a benefit decision’ service.",
   "fields": {
     "signer": {
       "label": "Enter your name",

--- a/steps/check-your-appeal/content.en.json
+++ b/steps/check-your-appeal/content.en.json
@@ -21,11 +21,11 @@
   "reasonsForAppealing": "Reasons for appealing",
   "fields": {
     "signer": {
+      "label": "Enter your name",
+      "hint": "This should be the person who is named on the appeal",
       "error": {
         "required": "Enter a Name"
-      },
-      "label": "Enter your name",
-      "hint": "This should be the person who is named on the appeal"
+      }
     }
   },
   "submitButton": {

--- a/steps/check-your-appeal/template.html
+++ b/steps/check-your-appeal/template.html
@@ -2,56 +2,21 @@
 {% extends "look-and-feel/layouts/check_your_answers.html" %}
 {% from "look-and-feel/components/fields.njk" import textbox, formSection, hiddenInput %}
 
+{% set pageContent = {
+    sendApplication: content.submitButton.value
+    }
+%}
 
-{% block two_thirds %}
-
-    {{ header(title | default('Check your answers')) }}
-
-    {% for section in _sections %}
-
-        {% if section.atLeast1Completed %}
-            {% if section.title and _sections|length > 1 %}
-                {{ header(section.title, size='medium') }}
-            {% endif %}
-
-            <dl class="govuk-check-your-answers cya-questions-short">
-                {% for part in section.completedAnswers %}
-                    {% if not part.hide %}
-                        {% if part.html %}
-                            {{ part.html | safe }}
-                        {% else %}
-                            {{ answer(part.question, part.answer, part.url) }}
-                        {% endif %}
-                    {% endif %}
-                {% endfor %}
-            </dl>
-        {% endif %}
-    {% endfor %}
-
-    {% if incomplete %}
-        {% block continue_application %}
-            {{ header('Your application is incomplete', size='medium') }}
-            <p>There are still some questions to answer.</p>
-            <a href="{{ continueUrl }}" class="button">Continue your application</a>
-        {% endblock %}
-    {% endif %}
-
-    {% if complete %}
-        {% block statement_of_truth_content %}
-            {{ header('Sign and submit', size='medium') }}
-            <p>The information I have provided in this appeal is accurate, to the best of my knowledge.</p>
-            <p>I give permission for you to correspond with my named representative about my appeal.</p>
-            <p>I agree to the <a href="/terms-and-conditions">terms and conditions</a> of using the ‘Appeal a benefit decision’ service.</p>
-        {% endblock %}
-
-        <form action="{{ path if path else url }}" method="post" class="form">
-
-            {% call formSection() %}
-                {{ textbox(fields.signer, content.fields.signer.label, hint=content.fields.signer.hint) }}
-            {% endcall %}
-
-            <input class="button" type="submit" value="{{ content.submitButton.value }}">
-        </form>
-    {% endif %}
-
+{% block statement_of_truth_content %}
+    {{ header('Sign and submit', size='medium') }}
+    <p>The information I have provided in this appeal is accurate, to the best of my knowledge.</p>
+    <p>I give permission for you to correspond with my named representative about my appeal.</p>
+    <p>I agree to the <a href="/terms-and-conditions">terms and conditions</a> of using the ‘Appeal a benefit decision’ service.</p>
 {% endblock %}
+
+{% block statement_of_truth_fields %}
+    {% call formSection() %}
+        {{ textbox(fields.signer, content.fields.signer.label, hint=content.fields.signer.hint) }}
+    {% endcall %}
+{%- endblock %}
+

--- a/steps/check-your-appeal/template.html
+++ b/steps/check-your-appeal/template.html
@@ -1,2 +1,9 @@
 {% extends "components/globals.html" %}
 {% extends "look-and-feel/layouts/check_your_answers.html" %}
+
+{% block statement_of_truth_content %}
+    {{ header('Sign and submit', size='medium') }}
+    <p>The information I have provided in this appeal is accurate, to the best of my knowledge.</p>
+    <p>I give permission for you to correspond with my named representative about my appeal.</p>
+    <p>I agree to the terms and conditions of using the ‘Appeal a benefit decision’ service.</p>
+{% endblock %}

--- a/steps/check-your-appeal/template.html
+++ b/steps/check-your-appeal/template.html
@@ -1,11 +1,57 @@
 {% extends "components/globals.html" %}
 {% extends "look-and-feel/layouts/check_your_answers.html" %}
+{% from "look-and-feel/components/fields.njk" import textbox, formSection, hiddenInput %}
 
-{% block statement_of_truth_content %}
 
-    {{ header('Sign and submit', size='medium') }}
-    <p>The information I have provided in this appeal is accurate, to the best of my knowledge.</p>
-    <p>I give permission for you to correspond with my named representative about my appeal.</p>
-    <p>I agree to the <a href="/terms-and-conditions">terms and conditions</a> of using the ‘Appeal a benefit decision’ service.</p>
+{% block two_thirds %}
+
+    {{ header(title | default('Check your answers')) }}
+
+    {% for section in _sections %}
+
+        {% if section.atLeast1Completed %}
+            {% if section.title and _sections|length > 1 %}
+                {{ header(section.title, size='medium') }}
+            {% endif %}
+
+            <dl class="govuk-check-your-answers cya-questions-short">
+                {% for part in section.completedAnswers %}
+                    {% if not part.hide %}
+                        {% if part.html %}
+                            {{ part.html | safe }}
+                        {% else %}
+                            {{ answer(part.question, part.answer, part.url) }}
+                        {% endif %}
+                    {% endif %}
+                {% endfor %}
+            </dl>
+        {% endif %}
+    {% endfor %}
+
+    {% if incomplete %}
+        {% block continue_application %}
+            {{ header('Your application is incomplete', size='medium') }}
+            <p>There are still some questions to answer.</p>
+            <a href="{{ continueUrl }}" class="button">Continue your application</a>
+        {% endblock %}
+    {% endif %}
+
+    {% if complete %}
+        {% block statement_of_truth_content %}
+            {{ header('Sign and submit', size='medium') }}
+            <p>The information I have provided in this appeal is accurate, to the best of my knowledge.</p>
+            <p>I give permission for you to correspond with my named representative about my appeal.</p>
+            <p>I agree to the <a href="/terms-and-conditions">terms and conditions</a> of using the ‘Appeal a benefit decision’ service.</p>
+        {% endblock %}
+
+        <form action="{{ path if path else url }}" method="post" class="form">
+
+            {% call formSection() %}
+                {{ textbox(fields.signer, content.fields.signer.label, hint=content.fields.signer.hint) }}
+            {% endcall %}
+
+            <input class="button" type="submit" value="{{ content.submitButton.value }}">
+        </form>
+    {% endif %}
 
 {% endblock %}

--- a/steps/check-your-appeal/template.html
+++ b/steps/check-your-appeal/template.html
@@ -8,10 +8,10 @@
 %}
 
 {% block statement_of_truth_content %}
-    {{ header('Sign and submit', size='medium') }}
-    <p>The information I have provided in this appeal is accurate, to the best of my knowledge.</p>
-    <p>I give permission for you to correspond with my named representative about my appeal.</p>
-    <p>I agree to the <a href="/terms-and-conditions">terms and conditions</a> of using the ‘Appeal a benefit decision’ service.</p>
+    {{ header(content.header, size='medium') }}
+    <p>{{ content.information }}</p>
+    <p>{{ content.permission }}</p>
+    <p>{{ content.agree | safe }}</p>
 {% endblock %}
 
 {% block statement_of_truth_fields %}

--- a/steps/check-your-appeal/template.html
+++ b/steps/check-your-appeal/template.html
@@ -2,8 +2,10 @@
 {% extends "look-and-feel/layouts/check_your_answers.html" %}
 
 {% block statement_of_truth_content %}
+
     {{ header('Sign and submit', size='medium') }}
     <p>The information I have provided in this appeal is accurate, to the best of my knowledge.</p>
     <p>I give permission for you to correspond with my named representative about my appeal.</p>
-    <p>I agree to the terms and conditions of using the ‘Appeal a benefit decision’ service.</p>
+    <p>I agree to the <a href="/terms-and-conditions">terms and conditions</a> of using the ‘Appeal a benefit decision’ service.</p>
+
 {% endblock %}

--- a/steps/check-your-appeal/template.html
+++ b/steps/check-your-appeal/template.html
@@ -1,6 +1,6 @@
 {% extends "components/globals.html" %}
 {% extends "look-and-feel/layouts/check_your_answers.html" %}
-{% from "look-and-feel/components/fields.njk" import textbox, formSection, hiddenInput %}
+{% from "look-and-feel/components/fields.njk" import textbox, formSection %}
 
 {% set pageContent = {
     sendApplication: content.submitButton.value

--- a/steps/compliance/check-mrn/CheckMRN.js
+++ b/steps/compliance/check-mrn/CheckMRN.js
@@ -31,6 +31,14 @@ class CheckMRN extends Question {
         );
     }
 
+    answers() {
+        return answer(this, { hide: true });
+    }
+
+    values() {
+        return {};
+    }
+
     next() {
 
         const mrnDate = DateUtils.createMoment(

--- a/steps/compliance/check-mrn/CheckMRN.js
+++ b/steps/compliance/check-mrn/CheckMRN.js
@@ -32,10 +32,12 @@ class CheckMRN extends Question {
     }
 
     answers() {
+
         return answer(this, { hide: true });
     }
 
     values() {
+
         return {};
     }
 

--- a/steps/compliance/check-mrn/CheckMRN.js
+++ b/steps/compliance/check-mrn/CheckMRN.js
@@ -31,16 +31,6 @@ class CheckMRN extends Question {
         );
     }
 
-    answers() {
-
-        return [];
-    }
-
-    values() {
-
-        return {};
-    }
-
     next() {
 
         const mrnDate = DateUtils.createMoment(

--- a/steps/compliance/have-a-mrn/HaveAMRN.js
+++ b/steps/compliance/have-a-mrn/HaveAMRN.js
@@ -2,6 +2,7 @@
 
 const { Question, goTo, branch } = require('@hmcts/one-per-page');
 const { form, textField } = require('@hmcts/one-per-page/forms');
+const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
 const Joi = require('joi');
 const paths = require('paths');
 const userAnswer = require('utils/answer');
@@ -22,6 +23,14 @@ class HaveAMRN extends Question {
                 Joi.string().valid([userAnswer.YES, userAnswer.NO]).required()
             )
         );
+    }
+
+    answers() {
+        return answer(this, { hide: true });
+    }
+
+    values() {
+        return {};
     }
 
     next() {

--- a/steps/compliance/have-a-mrn/HaveAMRN.js
+++ b/steps/compliance/have-a-mrn/HaveAMRN.js
@@ -24,16 +24,6 @@ class HaveAMRN extends Question {
         );
     }
 
-    answers() {
-
-        return [];
-    }
-
-    values() {
-
-        return {};
-    }
-
     next() {
 
         const hasAMRN = this.fields.haveAMRN.value === userAnswer.YES;

--- a/steps/compliance/have-a-mrn/HaveAMRN.js
+++ b/steps/compliance/have-a-mrn/HaveAMRN.js
@@ -26,10 +26,12 @@ class HaveAMRN extends Question {
     }
 
     answers() {
+
         return answer(this, { hide: true });
     }
 
     values() {
+
         return {};
     }
 

--- a/steps/compliance/have-contacted-dwp/HaveContactedDWP.js
+++ b/steps/compliance/have-contacted-dwp/HaveContactedDWP.js
@@ -24,16 +24,6 @@ class HaveContactedDWP extends Question {
         );
     }
 
-    answers() {
-
-        return [];
-    }
-
-    values() {
-
-        return {};
-    }
-
     next() {
 
         const hasContactDWP = this.fields.haveContactedDWP.value === userAnswer.YES;

--- a/steps/compliance/have-contacted-dwp/HaveContactedDWP.js
+++ b/steps/compliance/have-contacted-dwp/HaveContactedDWP.js
@@ -2,6 +2,7 @@
 
 const { Question, goTo, branch } = require('@hmcts/one-per-page');
 const { form, textField } = require('@hmcts/one-per-page/forms');
+const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
 const Joi = require('joi');
 const paths = require('paths');
 const userAnswer = require('utils/answer');
@@ -23,6 +24,15 @@ class HaveContactedDWP extends Question {
             )
         );
     }
+
+    answers() {
+        return answer(this, { hide: true });
+    }
+
+    values() {
+        return {};
+    }
+
 
     next() {
 

--- a/steps/compliance/have-contacted-dwp/HaveContactedDWP.js
+++ b/steps/compliance/have-contacted-dwp/HaveContactedDWP.js
@@ -26,10 +26,12 @@ class HaveContactedDWP extends Question {
     }
 
     answers() {
+
         return answer(this, { hide: true });
     }
 
     values() {
+
         return {};
     }
 

--- a/steps/hearing/not-attending/NotAttendingHearing.js
+++ b/steps/hearing/not-attending/NotAttendingHearing.js
@@ -24,11 +24,6 @@ class NotAttendingHearing extends Question {
         return this.fields.emailAddress.value ? 'email' : 'post';
     }
 
-    answers() {
-
-        return [];
-    }
-
     next() {
 
         return goTo(this.journey.steps.CheckYourAppeal);

--- a/steps/hearing/not-attending/NotAttendingHearing.js
+++ b/steps/hearing/not-attending/NotAttendingHearing.js
@@ -2,6 +2,7 @@
 
 const { Question, goTo } = require('@hmcts/one-per-page');
 const { form, textField } = require('@hmcts/one-per-page/forms');
+const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
 const paths = require('paths');
 
 class NotAttendingHearing extends Question {
@@ -17,6 +18,10 @@ class NotAttendingHearing extends Question {
 
             textField.ref(this.journey.steps.AppellantContactDetails, 'emailAddress')
         );
+    }
+
+    answers() {
+        return answer(this, { hide: true });
     }
 
     get byPostOrEmail() {

--- a/steps/hearing/not-attending/NotAttendingHearing.js
+++ b/steps/hearing/not-attending/NotAttendingHearing.js
@@ -21,6 +21,7 @@ class NotAttendingHearing extends Question {
     }
 
     answers() {
+
         return answer(this, { hide: true });
     }
 

--- a/steps/hearing/support/HearingSupport.js
+++ b/steps/hearing/support/HearingSupport.js
@@ -7,6 +7,7 @@ const { titleise } = require('utils/stringUtils');
 const Joi = require('joi');
 const paths = require('paths');
 const userAnswer = require('utils/answer');
+const sections = require('steps/check-your-appeal/sections');
 
 class HearingSupport extends Question {
 
@@ -32,7 +33,7 @@ class HearingSupport extends Question {
 
             answer(this, {
                 question: this.content.cya.arrangements.question,
-                section: 'hearing',
+                section: sections.theHearing,
                 answer: titleise(this.fields.arrangements.value)
             })
         ];

--- a/steps/hearing/the-hearing/TheHearing.js
+++ b/steps/hearing/the-hearing/TheHearing.js
@@ -7,6 +7,7 @@ const { titleise } = require('utils/stringUtils');
 const Joi = require('joi');
 const paths = require('paths');
 const userAnswer = require('utils/answer');
+const sections = require('steps/check-your-appeal/sections');
 
 class TheHearing extends Question {
 
@@ -30,7 +31,7 @@ class TheHearing extends Question {
 
         return answer(this, {
             question: this.content.cya.attendHearing.question,
-            section: 'hearing',
+            section: sections.theHearing,
             answer: titleise(this.fields.attendHearing.value)
         });
     }

--- a/steps/identity/appellant-nino/template.html
+++ b/steps/identity/appellant-nino/template.html
@@ -12,7 +12,7 @@
 
         <p>{{ content.subtitle }}</p>
 
-        {{ textbox(fields.nino, "", hint="") }}
+        {{ textbox(fields.nino, "") }}
 
     {% endcall %}
 

--- a/steps/reasons-for-appealing/other-reasons-for-appealing/OtherReasonForAppealing.js
+++ b/steps/reasons-for-appealing/other-reasons-for-appealing/OtherReasonForAppealing.js
@@ -19,9 +19,9 @@ class OtherReasonForAppealing extends Question {
 
         return form(
 
-            textField('otherReasonForAppealing')
-                .joi(this.content.fields.otherReasonForAppealing.error.invalid,
-                    Joi.string().regex(whitelist).allow('').required())
+            textField('otherReasonForAppealing').joi(
+                this.content.fields.otherReasonForAppealing.error.invalid,
+                Joi.string().regex(whitelist).allow(''))
         );
     }
 

--- a/steps/reasons-for-appealing/other-reasons-for-appealing/OtherReasonForAppealing.js
+++ b/steps/reasons-for-appealing/other-reasons-for-appealing/OtherReasonForAppealing.js
@@ -19,10 +19,9 @@ class OtherReasonForAppealing extends Question {
 
         return form(
 
-            textField('otherReasonForAppealing').joi(
-                this.content.fields.otherReasonForAppealing.error.invalid,
-                Joi.string().allow('').regex(whitelist)
-            )
+            textField('otherReasonForAppealing')
+                .joi(this.content.fields.otherReasonForAppealing.error.invalid,
+                    Joi.string().regex(whitelist).allow('').required())
         );
     }
 

--- a/steps/reasons-for-appealing/reason-for-appealing/ReasonForAppealing.js
+++ b/steps/reasons-for-appealing/reason-for-appealing/ReasonForAppealing.js
@@ -17,12 +17,13 @@ class ReasonForAppealing extends Question {
 
     get form() {
 
+        const reasonForAppealing = this.content.fields.reasonForAppealing;
+
         return form(
 
-            textField('reasonForAppealing').joi(
-                this.content.fields.reasonForAppealing.error.required,
-                Joi.string().regex(whitelist)
-            )
+            textField('reasonForAppealing')
+                .joi(reasonForAppealing.error.invalid,
+                    Joi.string().regex(whitelist).allow('').required())
         );
     }
 

--- a/steps/reasons-for-appealing/reason-for-appealing/ReasonForAppealing.js
+++ b/steps/reasons-for-appealing/reason-for-appealing/ReasonForAppealing.js
@@ -21,9 +21,9 @@ class ReasonForAppealing extends Question {
 
         return form(
 
-            textField('reasonForAppealing')
-                .joi(reasonForAppealing.error.invalid,
-                    Joi.string().regex(whitelist).allow('').required())
+            textField('reasonForAppealing').joi(
+                reasonForAppealing.error.required,
+                Joi.string().regex(whitelist).trim().required())
         );
     }
 

--- a/steps/reasons-for-appealing/sending-evidence/SendingEvidence.js
+++ b/steps/reasons-for-appealing/sending-evidence/SendingEvidence.js
@@ -26,6 +26,7 @@ class SendingEvidence extends Question {
     }
 
     answers() {
+
         return answer(this, { hide: true });
     }
 

--- a/steps/reasons-for-appealing/sending-evidence/SendingEvidence.js
+++ b/steps/reasons-for-appealing/sending-evidence/SendingEvidence.js
@@ -24,11 +24,6 @@ class SendingEvidence extends Question {
         );
     }
 
-    answers() {
-
-        return [];
-    }
-
     next() {
 
         return goTo(this.journey.steps.TheHearing);

--- a/steps/reasons-for-appealing/sending-evidence/SendingEvidence.js
+++ b/steps/reasons-for-appealing/sending-evidence/SendingEvidence.js
@@ -2,6 +2,7 @@
 
 const { Question, goTo } = require('@hmcts/one-per-page');
 const { form, textField } = require('@hmcts/one-per-page/forms');
+const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
 const paths = require('paths');
 
 class SendingEvidence extends Question {
@@ -22,6 +23,10 @@ class SendingEvidence extends Question {
 
             textField.ref(this.journey.steps.AppellantContactDetails, 'emailAddress')
         );
+    }
+
+    answers() {
+        return answer(this, { hide: true });
     }
 
     next() {

--- a/steps/representative/no-representative-details/NoRepresentativeDetails.js
+++ b/steps/representative/no-representative-details/NoRepresentativeDetails.js
@@ -18,6 +18,7 @@ class NoRepresentativeDetails extends Question {
     }
 
     answers() {
+
         return answer(this, { hide: true });
     }
 

--- a/steps/representative/no-representative-details/NoRepresentativeDetails.js
+++ b/steps/representative/no-representative-details/NoRepresentativeDetails.js
@@ -2,6 +2,7 @@
 
 const { Question, goTo } = require('@hmcts/one-per-page');
 const { form } = require('@hmcts/one-per-page/forms');
+const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
 const paths = require('paths');
 
 class NoRepresentativeDetails extends Question {
@@ -14,6 +15,10 @@ class NoRepresentativeDetails extends Question {
     get form() {
 
         return form();
+    }
+
+    answers() {
+        return answer(this, { hide: true });
     }
 
     values() {

--- a/steps/representative/no-representative-details/NoRepresentativeDetails.js
+++ b/steps/representative/no-representative-details/NoRepresentativeDetails.js
@@ -16,11 +16,6 @@ class NoRepresentativeDetails extends Question {
         return form();
     }
 
-    answers() {
-
-        return [];
-    }
-
     values() {
 
         return {

--- a/steps/sms-notify/enter-mobile/EnterMobile.js
+++ b/steps/sms-notify/enter-mobile/EnterMobile.js
@@ -28,6 +28,7 @@ class EnterMobile extends Question {
     }
 
     answers() {
+
         return answer(this, { hide: true });
     }
 
@@ -41,6 +42,7 @@ class EnterMobile extends Question {
     }
 
     next() {
+
         return goTo(this.journey.steps.SmsConfirmation);
     }
 }

--- a/steps/sms-notify/enter-mobile/EnterMobile.js
+++ b/steps/sms-notify/enter-mobile/EnterMobile.js
@@ -2,6 +2,7 @@
 
 const { Question, goTo } = require('@hmcts/one-per-page');
 const { form, textField } = require('@hmcts/one-per-page/forms');
+const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
 const { internationalMobileNumber } = require('utils/regex');
 const Joi = require('joi');
 const paths = require('paths');
@@ -24,6 +25,10 @@ class EnterMobile extends Question {
                 Joi.string().regex(internationalMobileNumber).required()
             )
         );
+    }
+
+    answers() {
+        return answer(this, { hide: true });
     }
 
     values() {

--- a/steps/sms-notify/enter-mobile/EnterMobile.js
+++ b/steps/sms-notify/enter-mobile/EnterMobile.js
@@ -26,11 +26,6 @@ class EnterMobile extends Question {
         );
     }
 
-    answers() {
-
-        return [];
-    }
-
     values() {
 
         return {

--- a/steps/sms-notify/send-to-number/SendToNumber.js
+++ b/steps/sms-notify/send-to-number/SendToNumber.js
@@ -34,6 +34,7 @@ class SendToNumber extends Question {
     }
 
     answers() {
+
         return answer(this, { hide: true });
     }
 

--- a/steps/sms-notify/send-to-number/SendToNumber.js
+++ b/steps/sms-notify/send-to-number/SendToNumber.js
@@ -32,11 +32,6 @@ class SendToNumber extends Question {
         );
     }
 
-    answers() {
-
-        return [];
-    }
-
     values() {
 
         return {

--- a/steps/sms-notify/send-to-number/SendToNumber.js
+++ b/steps/sms-notify/send-to-number/SendToNumber.js
@@ -2,6 +2,7 @@
 
 const { Question, goTo, branch } = require('@hmcts/one-per-page');
 const { form, textField } = require('@hmcts/one-per-page/forms');
+const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
 const { whitelist } = require('utils/regex');
 const Joi = require('joi');
 const paths = require('paths');
@@ -30,6 +31,10 @@ class SendToNumber extends Question {
                 Joi.string().regex(whitelist).required()
             )
         );
+    }
+
+    answers() {
+        return answer(this, { hide: true });
     }
 
     values() {

--- a/steps/start/independence/Independence.js
+++ b/steps/start/independence/Independence.js
@@ -12,6 +12,7 @@ class Independence extends Question {
     }
 
     answers() {
+
         return answer(this, { hide: true });
     }
 

--- a/steps/start/independence/Independence.js
+++ b/steps/start/independence/Independence.js
@@ -10,11 +10,6 @@ class Independence extends Question {
         return paths.start.independence;
     }
 
-    answers() {
-
-        return [];
-    }
-
     next() {
 
         return goTo(this.journey.steps.HaveAMRN);

--- a/steps/start/independence/Independence.js
+++ b/steps/start/independence/Independence.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Question, goTo } = require('@hmcts/one-per-page');
+const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
 const paths = require('paths');
 
 class Independence extends Question {
@@ -8,6 +9,10 @@ class Independence extends Question {
     static get path() {
 
         return paths.start.independence;
+    }
+
+    answers() {
+        return answer(this, { hide: true });
     }
 
     next() {

--- a/steps/start/postcode-checker/PostcodeChecker.js
+++ b/steps/start/postcode-checker/PostcodeChecker.js
@@ -26,11 +26,6 @@ class PostcodeChecker extends Question {
         );
     }
 
-    answers() {
-
-        return [];
-    }
-
     values() {
 
         return {

--- a/steps/start/postcode-checker/PostcodeChecker.js
+++ b/steps/start/postcode-checker/PostcodeChecker.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const { Question, branch, goTo } = require('@hmcts/one-per-page');
-const { form, textField } = require('@hmcts/one-per-page/forms');
-const { postCode, inwardPostcode } = require('utils/regex');
+const {Question, branch, goTo} = require('@hmcts/one-per-page');
+const {form, textField} = require('@hmcts/one-per-page/forms');
+const {answer} = require('@hmcts/one-per-page/checkYourAnswers');
+const {postCode, inwardPostcode} = require('utils/regex');
 const postcodeList = require('steps/start/postcode-checker/validPostcodeList');
 const Joi = require('joi');
 const paths = require('paths');
@@ -17,13 +18,16 @@ class PostcodeChecker extends Question {
     get form() {
 
         return form(
-
             textField('postcode').joi(
                 this.content.fields.postcode.error.emptyField,
                 Joi.string().required()).joi(
                 this.content.fields.postcode.error.invalid,
                 Joi.string().regex(postCode))
         );
+    }
+
+    answers() {
+        return answer(this, {hide: true});
     }
 
     values() {

--- a/steps/start/postcode-checker/PostcodeChecker.js
+++ b/steps/start/postcode-checker/PostcodeChecker.js
@@ -27,6 +27,7 @@ class PostcodeChecker extends Question {
     }
 
     answers() {
+
         return answer(this, {hide: true});
     }
 

--- a/test/e2e/scenarios/check-your-appeal/checkYourAppeal.js
+++ b/test/e2e/scenarios/check-your-appeal/checkYourAppeal.js
@@ -23,12 +23,10 @@ Scenario('When the appeal is incomplete, I am taken to the next step that needs 
 
 })
 
-Scenario('When I go to the check your appeal page, I see the Sign and submit section', (I) => {
+Scenario('When I go to the check your appeal page, I don\'t see the Sign and submit section', (I) => {
 
     I.enterBenefitTypeAndContinue('pip');
     I.amOnPage(paths.checkYourAppeal);
-    I.see('Sign and submit');
-    I.click('terms and conditions');
-    I.seeInCurrentUrl('/terms-and-conditions');
+    I.dontSee('Sign and submit');
 
 });

--- a/test/e2e/scenarios/check-your-appeal/checkYourAppeal.js
+++ b/test/e2e/scenarios/check-your-appeal/checkYourAppeal.js
@@ -21,7 +21,7 @@ Scenario('When the appeal is incomplete, I am taken to the next step that needs 
     I.click('Continue your application');
     I.seeCurrentUrlEquals('/benefit-type');
 
-})
+});
 
 Scenario('When I go to the check your appeal page, I don\'t see the Sign and submit section', (I) => {
 

--- a/test/e2e/scenarios/check-your-appeal/checkYourAppeal.js
+++ b/test/e2e/scenarios/check-your-appeal/checkYourAppeal.js
@@ -6,17 +6,15 @@ Feature('Check-your-appeal');
 
 Before((I) => {
     I.createTheSession();
-    I.enterBenefitTypeAndContinue('pip');
-    I.amOnPage(paths.checkYourAppeal);
 });
 
 After((I) => {
     I.endTheSession();
 });
 
-//TODO: Please, review this test since the wording does not seem to match the test implementation
-xScenario('When I click submit your appeal, I am taken to the confirmation page', (I) => {
+Scenario('When the appeal is incomplete, I am taken to the next step that needs completing', (I) => {
 
+    I.amOnPage(paths.checkYourAppeal);
     I.see('Check your answers');
     I.see('Your application is incomplete');
     I.see('There are still some questions to answer');
@@ -27,6 +25,8 @@ xScenario('When I click submit your appeal, I am taken to the confirmation page'
 
 Scenario('When I go to the check your appeal page, I see the Sign and submit section', (I) => {
 
+    I.enterBenefitTypeAndContinue('pip');
+    I.amOnPage(paths.checkYourAppeal);
     I.see('Sign and submit');
     I.click('terms and conditions');
     I.seeInCurrentUrl('/terms-and-conditions');

--- a/test/e2e/scenarios/check-your-appeal/checkYourAppeal.js
+++ b/test/e2e/scenarios/check-your-appeal/checkYourAppeal.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const paths = require('paths');
-const content = require('steps/check-your-appeal/content.en.json');
 
 Feature('Check-your-appeal');
 
 Before((I) => {
     I.createTheSession();
+    I.enterBenefitTypeAndContinue('pip');
     I.amOnPage(paths.checkYourAppeal);
 });
 
@@ -14,12 +14,21 @@ After((I) => {
     I.endTheSession();
 });
 
-Scenario('When I click submit your appeal, I am taken to the confirmation page', (I) => {
+//TODO: Please, review this test since the wording does not seem to match the test implementation
+xScenario('When I click submit your appeal, I am taken to the confirmation page', (I) => {
 
     I.see('Check your answers');
     I.see('Your application is incomplete');
     I.see('There are still some questions to answer');
     I.click('Continue your application');
     I.seeCurrentUrlEquals('/benefit-type');
+
+})
+
+Scenario('When I go to the check your appeal page, I see the Sign and submit section', (I) => {
+
+    I.see('Sign and submit');
+    I.click('terms and conditions');
+    I.seeInCurrentUrl('/terms-and-conditions');
 
 });

--- a/test/e2e/scenarios/cya/appellant/pip/does-not-attend-hearing.js
+++ b/test/e2e/scenarios/cya/appellant/pip/does-not-attend-hearing.js
@@ -151,7 +151,7 @@ const IconfirmDetailsArePresent = (I) => {
     I.see('Anything else...');
 
     // Shows when the appeal is complete
-    I.see('Now send your application');
+    I.see('Sign and submit');
 
 };
 

--- a/test/unit/steps/check-your-appeal/CheckYourAppeal.test.js
+++ b/test/unit/steps/check-your-appeal/CheckYourAppeal.test.js
@@ -112,4 +112,11 @@ describe('CheckYourAppeal.js', () => {
 
     });
 
+    describe('termsAndConditionPath()', () => {
+
+        it('should return /terms-and-conditions', () => {
+            expect(cya.termsAndConditionPath).to.equal(paths.policy.termsAndConditions);
+        });
+    });
+
 });

--- a/test/unit/steps/check-your-appeal/CheckYourAppeal.test.js
+++ b/test/unit/steps/check-your-appeal/CheckYourAppeal.test.js
@@ -10,6 +10,8 @@ describe('CheckYourAppeal.js', () => {
     let CheckYourAppeal;
     let request = {};
     let cya;
+    let field;
+
 
     before(() => {
 
@@ -32,6 +34,14 @@ describe('CheckYourAppeal.js', () => {
                 }
             }
         });
+
+        cya.fields = {
+            signer: {
+                value: "Mr Tester"
+            }
+        };
+
+        field = cya.form.fields[0];
     });
 
     describe('get path()', () => {
@@ -65,6 +75,30 @@ describe('CheckYourAppeal.js', () => {
             Object.values(sections).map(function(value, index) {
                 expect(cyaSections[index].id).to.equal(value);
             });
+        });
+
+    });
+
+    describe('get form()', () => {
+
+        describe('signer field', () => {
+
+            it('contains a field with the name signer', () => {
+                expect(field.name).to.equal('signer');
+            });
+
+            it('contains validation', () => {
+                expect(field.validations).to.not.be.empty;
+            });
+
+        });
+
+    });
+
+    describe('get values()', () => {
+
+        it('contains the signAndSubmit json object field', () => {
+            expect(cya.values().signAndSubmit.signer).to.equal('Mr Tester');
         });
 
     });

--- a/test/unit/steps/compliance/check-mrn/CheckMRN.test.js
+++ b/test/unit/steps/compliance/check-mrn/CheckMRN.test.js
@@ -75,6 +75,22 @@ describe('CheckMRN.js', () => {
 
     });
 
+    describe('answers()', () => {
+
+        it('should be hidden', () => {
+            expect(checkMRN.answers().hide).to.be.true;
+        });
+
+    });
+
+    describe('values()', () => {
+
+        it('should be empty', () => {
+            expect(checkMRN.values()).to.be.empty;
+        });
+
+    });
+
     describe('next()', () => {
 
         const setMRNDate = date => {

--- a/test/unit/steps/compliance/check-mrn/CheckMRN.test.js
+++ b/test/unit/steps/compliance/check-mrn/CheckMRN.test.js
@@ -75,22 +75,6 @@ describe('CheckMRN.js', () => {
 
     });
 
-    describe('answers()', () => {
-
-        it('should be empty', ()=> {
-            expect(checkMRN.answers()).to.be.empty;
-        });
-
-    });
-
-    describe('values()', () => {
-
-        it('should be empty', ()=> {
-            expect(checkMRN.values()).to.be.empty;
-        });
-
-    });
-
     describe('next()', () => {
 
         const setMRNDate = date => {

--- a/test/unit/steps/compliance/have-a-mrn/HaveAMRN.test.js
+++ b/test/unit/steps/compliance/have-a-mrn/HaveAMRN.test.js
@@ -50,22 +50,6 @@ describe('HaveAMRN.js', () => {
 
     });
 
-    describe('answers()', () => {
-
-        it('should be empty', ()=> {
-            expect(haveAMRN.answers()).to.be.empty;
-        });
-
-    });
-
-    describe('values()', () => {
-
-        it('should be empty', ()=> {
-            expect(haveAMRN.values()).to.be.empty;
-        });
-
-    });
-
     describe('next()', () => {
 
         it('returns the next step path /dwp-issuing-office when haveAMRN equals Yes', () => {

--- a/test/unit/steps/compliance/have-a-mrn/HaveAMRN.test.js
+++ b/test/unit/steps/compliance/have-a-mrn/HaveAMRN.test.js
@@ -50,6 +50,22 @@ describe('HaveAMRN.js', () => {
 
     });
 
+    describe('answers()', () => {
+
+        it('should be hidden', () => {
+            expect(haveAMRN.answers().hide).to.be.true;
+        });
+
+    });
+
+    describe('values()', () => {
+
+        it('should be empty', () => {
+            expect(haveAMRN.values()).to.be.empty;
+        });
+
+    });
+
     describe('next()', () => {
 
         it('returns the next step path /dwp-issuing-office when haveAMRN equals Yes', () => {

--- a/test/unit/steps/compliance/have-contacted-dwp/HaveContactedDWP.test.js
+++ b/test/unit/steps/compliance/have-contacted-dwp/HaveContactedDWP.test.js
@@ -49,22 +49,6 @@ describe('HaveContactedDWP.js', () => {
 
     });
 
-    describe('answers()', () => {
-
-        it('should be empty', ()=> {
-            expect(haveContactedDWP.answers()).to.be.empty;
-        });
-
-    });
-
-    describe('values()', () => {
-
-        it('should be empty', ()=> {
-            expect(haveContactedDWP.values()).to.be.empty;
-        });
-
-    });
-
     describe('next()', () => {
 
         it('returns the next step path /dwp-issuing-office when haveAMRN equals Yes', () => {

--- a/test/unit/steps/compliance/have-contacted-dwp/HaveContactedDWP.test.js
+++ b/test/unit/steps/compliance/have-contacted-dwp/HaveContactedDWP.test.js
@@ -49,6 +49,22 @@ describe('HaveContactedDWP.js', () => {
 
     });
 
+    describe('answers()', () => {
+
+        it('should be hidden', () => {
+            expect(haveContactedDWP.answers().hide).to.be.true;
+        });
+
+    });
+
+    describe('values()', () => {
+
+        it('should be empty', () => {
+            expect(haveContactedDWP.values()).to.be.empty;
+        });
+
+    });
+
     describe('next()', () => {
 
         it('returns the next step path /dwp-issuing-office when haveAMRN equals Yes', () => {

--- a/test/unit/steps/reasons-for-appealing/ReasonForAppealing.test.js
+++ b/test/unit/steps/reasons-for-appealing/ReasonForAppealing.test.js
@@ -82,15 +82,15 @@ describe('ReasonForAppealing.js', () => {
         });
 
         it('should return expected section', () => {
-            expect(answers.section).to.eql('reasons-for-appealing');
+            expect(answers.section).to.equal('reasons-for-appealing');
         });
 
         it('should return expected answers', () => {
-            expect(answers.answer).to.eql('my answer');
+            expect(answers.answer).to.equal('my answer');
         });
 
         it('should return expected question', () => {
-            expect(answers.question).to.eql('my question');
+            expect(answers.question).to.equal('my question');
         });
 
     });

--- a/test/unit/steps/reasons-for-appealing/ReasonForAppealing.test.js
+++ b/test/unit/steps/reasons-for-appealing/ReasonForAppealing.test.js
@@ -59,6 +59,8 @@ describe('ReasonForAppealing.js', () => {
 
     describe('get answers()', () => {
 
+        let answers;
+
         beforeEach(() => {
 
             reasonForAppealing.fields = {
@@ -75,21 +77,24 @@ describe('ReasonForAppealing.js', () => {
                 }
             };
 
+            answers = reasonForAppealing.answers()[0];
+
         });
 
         it('should return expected section', () => {
-            expect(reasonForAppealing.answers()[0].section).to.eql('reasons-for-appealing');
+            expect(answers.section).to.eql('reasons-for-appealing');
         });
 
-        it('should return expected answer', () => {
-            expect(reasonForAppealing.answers()[0].answer).to.eql('my answer');
+        it('should return expected answers', () => {
+            expect(answers.answer).to.eql('my answer');
         });
 
         it('should return expected question', () => {
-            expect(reasonForAppealing.answers()[0].question).to.eql('my question');
+            expect(answers.question).to.eql('my question');
         });
 
     });
+
 
     describe('next()', () => {
 

--- a/test/unit/steps/reasons-for-appealing/SendingEvidence.test.js
+++ b/test/unit/steps/reasons-for-appealing/SendingEvidence.test.js
@@ -46,6 +46,14 @@ describe('SendingEvidence.js', () => {
 
     });
 
+    describe('answers()', () => {
+
+        it('should be hidden', () => {
+            expect(sendingEvidence.answers().hide).to.be.true;
+        });
+
+    });
+
     describe('next()', () => {
 
         it('nextStep equals /the-hearing', () => {

--- a/test/unit/steps/reasons-for-appealing/SendingEvidence.test.js
+++ b/test/unit/steps/reasons-for-appealing/SendingEvidence.test.js
@@ -46,14 +46,6 @@ describe('SendingEvidence.js', () => {
 
     });
 
-    describe('answers()', () => {
-
-        it('should be empty', ()=> {
-            expect(sendingEvidence.answers()).to.be.empty;
-        });
-
-    });
-
     describe('next()', () => {
 
         it('nextStep equals /the-hearing', () => {

--- a/test/unit/steps/sms-notify/enter-mobile/EnterMobile.test.js
+++ b/test/unit/steps/sms-notify/enter-mobile/EnterMobile.test.js
@@ -46,6 +46,14 @@ describe('EnterMobile.js', () => {
 
     });
 
+    describe('answers()', () => {
+
+        it('should be hidden', () => {
+            expect(enterMobile.answers().hide).to.be.true;
+        });
+
+    });
+
     describe('values()', () => {
 
         const value = '07411435779';

--- a/test/unit/steps/sms-notify/enter-mobile/EnterMobile.test.js
+++ b/test/unit/steps/sms-notify/enter-mobile/EnterMobile.test.js
@@ -46,14 +46,6 @@ describe('EnterMobile.js', () => {
 
     });
 
-    describe('answers()', () => {
-
-        it('should be empty', ()=> {
-            expect(enterMobile.answers()).to.be.empty;
-        });
-
-    });
-
     describe('values()', () => {
 
         const value = '07411435779';

--- a/test/unit/steps/sms-notify/send-to-number/SendToNumber.test.js
+++ b/test/unit/steps/sms-notify/send-to-number/SendToNumber.test.js
@@ -69,6 +69,14 @@ describe('SendToNumber.js', () => {
 
     });
 
+    describe('answers()', () => {
+
+        it('should be hidden', () => {
+            expect(sendToNumber.answers().hide).to.be.true;
+        });
+
+    });
+
     describe('values()', () => {
 
         beforeEach(() => {

--- a/test/unit/steps/sms-notify/send-to-number/SendToNumber.test.js
+++ b/test/unit/steps/sms-notify/send-to-number/SendToNumber.test.js
@@ -69,14 +69,6 @@ describe('SendToNumber.js', () => {
 
     });
 
-    describe('answers()', () => {
-
-        it('should be empty', ()=> {
-            expect(sendToNumber.answers()).to.be.empty;
-        });
-
-    });
-
     describe('values()', () => {
 
         beforeEach(() => {

--- a/test/unit/steps/start/Independence.test.js
+++ b/test/unit/steps/start/Independence.test.js
@@ -28,14 +28,6 @@ describe('Independence.js', () => {
 
     });
 
-    describe('answers()', () => {
-
-        it('should be empty', ()=> {
-            expect(independence.answers()).to.be.empty;
-        });
-
-    });
-
     describe('next()', () => {
 
         it('returns the next step path /mrn-date', () => {

--- a/test/unit/steps/start/Independence.test.js
+++ b/test/unit/steps/start/Independence.test.js
@@ -20,6 +20,14 @@ describe('Independence.js', () => {
 
     });
 
+    describe('answers()', () => {
+
+        it('should be hidden', () => {
+            expect(independence.answers().hide).to.be.true;
+        });
+
+    });
+
     describe('get path()', () => {
 
         it('returns path /independence', () => {

--- a/test/unit/steps/start/PostcodeChecker.test.js
+++ b/test/unit/steps/start/PostcodeChecker.test.js
@@ -47,6 +47,14 @@ describe('PostcodeChecker.js', () => {
 
     });
 
+    describe('answers()', () => {
+
+        it('should be hidden', () => {
+            expect(postcodeChecker.answers().hide).to.be.true;
+        });
+
+    });
+
     describe('values()', () => {
 
         it('should...', ()=> {

--- a/test/unit/steps/start/PostcodeChecker.test.js
+++ b/test/unit/steps/start/PostcodeChecker.test.js
@@ -47,14 +47,6 @@ describe('PostcodeChecker.js', () => {
 
     });
 
-    describe('answers()', () => {
-
-        it('should be empty', ()=> {
-            expect(postcodeChecker.answers()).to.be.empty;
-        });
-
-    });
-
     describe('values()', () => {
 
         it('should...', ()=> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@hmcts/look-and-feel@^1.3.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@hmcts/look-and-feel/-/look-and-feel-1.6.0.tgz#9742019da694e6f4a47f4c00ae5d41c74be60f6a"
+"@hmcts/look-and-feel@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@hmcts/look-and-feel/-/look-and-feel-1.7.0.tgz#99e76ead0573f3488a3bb3cad26baed156f79be0"
   dependencies:
     babel-core "^6.26.0"
     babel-loader "^7.1.2"


### PR DESCRIPTION
Add to the CheckYourAppeal page the Sign and Submit section. 
Post the signer filed together with the JSON object being posted to the TYA API.
Minor refactors to other and non-related classes for this work but that I noticed we can make cleaner. 
Upgrade look-and-feel package to be able to use an improvement to override form content without having to override the whole two_thirds block. 
Add unit and e2e testing code
