### PR TITLE
Upgraded look-and-feel to v1.8.0-3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "health-check": "echo 'not implemented yet'"
   },
   "dependencies": {
-    "@hmcts/look-and-feel": "^1.8.0-1",
+    "@hmcts/look-and-feel": "^1.8.0-3",
     "@hmcts/nodejs-healthcheck": "^1.4.3",
     "@hmcts/one-per-page": "2.1.0-2",
     "accessible-autocomplete": "^1.6.1",

--- a/steps/check-your-appeal/selectors.js
+++ b/steps/check-your-appeal/selectors.js
@@ -1,0 +1,60 @@
+module.exports = {
+
+    benefitType:                '#cya-benefittype-benefit-name .cya-answer',
+
+    mrn: {
+        date:                   '#cya-mrndate-date-of-mrn .cya-answer',
+        dwpIssuingOffice:       '#cya-dwpissuingoffice-number-from-mrn-address .cya-answer',
+        noMRN:                  '#cya-nomrn-reason-for-no-mrn .cya-answer',
+        overOneMonthLate:       '#cya-mrnoveronemonthlate-why-your-appeal-is-late .cya-answer',
+        overThirteenMonthsLate: '#cya-mrnoverthirteenmonthslate-why-your-appeal-is-late .cya-answer'
+    },
+
+    appellant: {
+        appointee:              '#cya-appointee-appointee .cya-answer',
+        name:                   '#cya-appellantname-name .cya-answer',
+        dob:                    '#cya-appellantdob-date-of-birth .cya-answer',
+        nino:                   '#cya-appellantnino-national-insurance-number .cya-answer',
+        addressLine1:           '#cya-appellantcontactdetails-address-line-1 .cya-answer',
+        addressLine2:           '#cya-appellantcontactdetails-address-line-2 .cya-answer',
+        townCity:               '#cya-appellantcontactdetails-towncity .cya-answer',
+        county:                 '#cya-appellantcontactdetails-county .cya-answer',
+        postCode:               '#cya-appellantcontactdetails-postcode .cya-answer',
+        phoneNumber:            '#cya-appellantcontactdetails-phone-number .cya-answer',
+        email:                  '#cya-appellantcontactdetails-email .cya-answer'
+    },
+
+    textMsgReminders: {
+        receiveTxtMsgReminders: '#cya-textreminders-receive-text-message-reminders .cya-answer',
+        mobileNumber:           '#cya-smsconfirmation-mobile-number .cya-answer'
+    },
+
+    representative: {
+        haveARepresentative:    '#cya-representative-have-a-representative.cya-answer',
+        firstName:              '#cya-representativedetails-first-name .cya-answer',
+        lastName:               '#cya-representativedetails-last-name .cya-answer',
+        organisation:           '#cya-representativedetails-organisation-if-they-work-for-one .cya-answer',
+        addressLine1:           '#cya-representativedetails-address-line-1 .cya-answer',
+        addressLine2:           '#cya-representativedetails-address-line-2 .cya-answer',
+        townCity:               '#cya-representativedetails-towncity .cya-answer',
+        county:                 '#cya-representativedetails-county .cya-answer',
+        postCode:               '#cya-representativedetails-postcode .cya-answer',
+        phoneNumber:            '#cya-representativedetails-phone-number .cya-answer',
+        email:                  '#cya-representativedetails-email-address .cya-answer'
+    },
+
+    reasonsForAppealing: {
+        reasons:                '#cya-reasonforappealing-reason-for-appealing .cya-answer',
+        otherReasons:           '#cya-otherreasonforappealing-other-reasons-for-appealing .cya-answer'
+    },
+
+    theHearing: {
+        attendingTheHearing:    '#cya-thehearing-attending-the-hearing .cya-answer',
+        datesYouCantAttend:     '#cya-datescantattend-dates-youre-not-available .cya-answer'
+    },
+
+    hearingArrangements: {
+        yourArrangements:       '#cya-hearingarrangements-your-hearing-arrangement .cya-answer',
+        anyOtherArrangements:   '#cya-hearingarrangements-any-other-arrangements .cya-answer'
+    }
+};

--- a/steps/hearing/availability/HearingAvailability.js
+++ b/steps/hearing/availability/HearingAvailability.js
@@ -3,8 +3,6 @@
 const { Question, goTo, branch } = require('@hmcts/one-per-page');
 const { form, textField } = require('@hmcts/one-per-page/forms');
 const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
-const { titleise } = require('utils/stringUtils');
-const sections = require('steps/check-your-appeal/sections');
 const Joi = require('joi');
 const paths = require('paths');
 const userAnswer = require('utils/answer');
@@ -29,15 +27,7 @@ class HearingAvailability extends Question {
 
     answers() {
 
-        return [
-
-            answer(this, {
-                question: this.content.cya.scheduleHearing.question,
-                section: sections.theHearing,
-                answer: titleise(this.fields.scheduleHearing.value)
-            })
-        ];
-
+        return answer(this, {hide: true});
     }
 
     values() {

--- a/steps/hearing/support/HearingSupport.js
+++ b/steps/hearing/support/HearingSupport.js
@@ -3,11 +3,9 @@
 const { Question, branch, goTo } = require('@hmcts/one-per-page');
 const { form, textField } = require('@hmcts/one-per-page/forms');
 const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
-const { titleise } = require('utils/stringUtils');
 const Joi = require('joi');
 const paths = require('paths');
 const userAnswer = require('utils/answer');
-const sections = require('steps/check-your-appeal/sections');
 
 class HearingSupport extends Question {
 
@@ -29,14 +27,7 @@ class HearingSupport extends Question {
 
     answers() {
 
-        return [
-
-            answer(this, {
-                question: this.content.cya.arrangements.question,
-                section: sections.theHearing,
-                answer: titleise(this.fields.arrangements.value)
-            })
-        ];
+        return answer(this, {hide: true});
     }
 
     values() {

--- a/steps/identity/appellant-contact-details/AppellantContactDetails.js
+++ b/steps/identity/appellant-contact-details/AppellantContactDetails.js
@@ -95,16 +95,16 @@ class AppellantContactDetails extends Question {
             }),
 
             answer(this, {
+                question: this.content.cya.emailAddress.question,
+                section: sections.appellantDetails,
+                answer: this.fields.emailAddress.value || userAnswer.NOT_PROVIDED
+            }),
+
+            answer(this, {
                 question: this.content.cya.phoneNumber.question,
                 section: sections.appellantDetails,
                 answer: this.fields.phoneNumber.value || userAnswer.NOT_PROVIDED
             }),
-
-            answer(this, {
-                question: this.content.cya.emailAddress.question,
-                section: sections.appellantDetails,
-                answer: this.fields.emailAddress.value || userAnswer.NOT_PROVIDED
-            })
         ];
     }
 

--- a/steps/reasons-for-appealing/other-reasons-for-appealing/OtherReasonForAppealing.js
+++ b/steps/reasons-for-appealing/other-reasons-for-appealing/OtherReasonForAppealing.js
@@ -7,6 +7,7 @@ const { whitelist } = require('utils/regex');
 const sections = require('steps/check-your-appeal/sections');
 const paths = require('paths');
 const Joi = require('joi');
+const userAnswer = require('utils/answer');
 
 class OtherReasonForAppealing extends Question {
 
@@ -32,7 +33,7 @@ class OtherReasonForAppealing extends Question {
             answer(this, {
                 question: this.content.cya.otherReasonForAppealing.question,
                 section: sections.reasonsForAppealing,
-                answer: this.fields.otherReasonForAppealing.value
+                answer: this.fields.otherReasonForAppealing.value  || userAnswer.NOT_REQUIRED
             })
         ];
     }

--- a/steps/representative/representative-details/RepresentativeDetails.js
+++ b/steps/representative/representative-details/RepresentativeDetails.js
@@ -63,15 +63,15 @@ class RepresentativeDetails extends Question {
                 Joi.string().regex(postCode).required()
             ),
 
+            textField('emailAddress').joi(
+                fields.emailAddress.error.invalid,
+                Joi.string().email(emailOptions).allow('')
+            ),
+
             textField('phoneNumber').joi(
                 fields.phoneNumber.error.invalid,
                 Joi.string().regex(phoneNumber).allow('')
             ),
-
-            textField('emailAddress').joi(
-                fields.emailAddress.error.invalid,
-                Joi.string().email(emailOptions).allow('')
-            )
         );
     }
 

--- a/test/e2e/scenarios/cya/textMessageReminders.js
+++ b/test/e2e/scenarios/cya/textMessageReminders.js
@@ -6,6 +6,7 @@ const oneMonthAgo = DateUtils.oneMonthAgo();
 const textRemindersContent = require('steps/sms-notify/text-reminders/content.en.json');
 const haveAMRNContent = require('steps/compliance/have-a-mrn/content.en.json');
 const appointeeContent = require('steps/identity/appointee/content.en.json');
+const selectors = require('steps/check-your-appeal/selectors');
 
 Feature('Appellant PIP, one month ago, does not attend hearing.');
 
@@ -26,6 +27,8 @@ Scenario('Appellant does not define an optional phone number and does not sign u
     IenterDetailsFromNoRepresentativeToEnd(I);
 
     IconfirmDetailsArePresent(I);
+    I.see('Not provided', selectors.appellant.phoneNumber);
+    I.see('No', selectors.textMsgReminders.receiveTxtMsgReminders);
 
 });
 
@@ -39,7 +42,8 @@ Scenario('Appellant does not define an optional phone number, however, enters mo
     IenterDetailsFromNoRepresentativeToEnd(I);
 
     IconfirmDetailsArePresent(I);
-    ISeeValueInSection(I, '07455678444', 'Mobile Number', '/send-to-number');
+    I.see('Not provided', selectors.appellant.phoneNumber);
+    I.see('07455678444', selectors.textMsgReminders.mobileNumber);
 
 });
 
@@ -54,12 +58,12 @@ Scenario('Appellant defines an optional phone number and signs up for text msg r
     IenterDetailsFromNoRepresentativeToEnd(I);
 
     IconfirmDetailsArePresent(I);
-    ISeeValueInSection(I, '07411738663', 'Phone number',  '/enter-appellant-contact-details');
-    ISeeValueInSection(I, '07411738663', 'Mobile Number', '/send-to-number');
+    I.see('07411738663', selectors.appellant.phoneNumber);
+    I.see('07411738663', selectors.textMsgReminders.mobileNumber);
 
 });
 
-Scenario('Appellant defines an optional phone number, this is overridden by another number for text msg reminders.', (I) => {
+Scenario('Appellant defines an optional phone number, then provides an additional mobile number for text msg reminders.', (I) => {
 
     IenterDetailsFromStartToNINO(I);
 
@@ -71,8 +75,8 @@ Scenario('Appellant defines an optional phone number, this is overridden by anot
     IenterDetailsFromNoRepresentativeToEnd(I);
 
     IconfirmDetailsArePresent(I);
-    ISeeValueInSection(I, '07411738663', 'Phone number',  '/enter-appellant-contact-details');
-    ISeeValueInSection(I, '07411333333', 'Mobile Number', '/send-to-number');
+    I.see('07411738663', selectors.appellant.phoneNumber);
+    I.see('07411333333', selectors.textMsgReminders.mobileNumber);
 
 });
 
@@ -85,7 +89,8 @@ Scenario('Appellant defines an optional phone number, but does not sign up for t
     IenterDetailsFromNoRepresentativeToEnd(I);
 
     IconfirmDetailsArePresent(I);
-    ISeeValueInSection(I, '07411738663', 'Phone number',  '/enter-appellant-contact-details');
+    I.see('07411738663', selectors.appellant.phoneNumber);
+    I.see('No', selectors.textMsgReminders.receiveTxtMsgReminders);
 
 });
 
@@ -123,7 +128,7 @@ const IconfirmDetailsArePresent = (I) => {
     I.see('Personal Independence Payment (PIP)');
 
     // MRN address number
-    ISeeValueInSection(I, '1', 'Number from MRN address', '/dwp-issuing-office');
+    I.see('1', selectors.mrn.dwpIssuingOffice);
 
     // Date of MRN
     I.see(oneMonthAgo.format('DD MMMM YYYY'));
@@ -153,27 +158,4 @@ const IconfirmDetailsArePresent = (I) => {
     // Shows when the appeal is complete
     I.see('Sign and submit');
 
-};
-
-const ISeeValueInSection = (I, value, label, path) => {
-
-    const section = `<div>
-  <dt class="cya-question">
-    ${label}
-  </dt>
-  <dd class="cya-answer">
-    
-      
-        ${value}
-      
-    
-  </dd>
-  <dd class="cya-change">
-    <a href="${path}">
-      Change<span class="visually-hidden"> ${label}</span>
-    </a>
-  </dd>
-</div>`;
-
-    I.seeInSource(section);
 };

--- a/test/unit/steps/hearing/availability/HearingAvailability.test.js
+++ b/test/unit/steps/hearing/availability/HearingAvailability.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const HearingAvailability = require('steps/hearing/availability/HearingAvailability');
-const sections = require('steps/check-your-appeal/sections');
 const { expect } = require('test/util/chai');
 const paths = require('paths');
 
@@ -87,12 +86,9 @@ describe('HearingAvailability.js', () => {
 
         });
 
-        it('should contain a single answer', () => {
+        it('should contain a hidden answer', () => {
             const answers = hearingAvailability.answers();
-            expect(answers.length).to.equal(1);
-            expect(answers[0].question).to.equal(question);
-            expect(answers[0].section).to.equal(sections.theHearing);
-            expect(answers[0].answer).to.equal(value);
+            expect(answers.hide).to.be.true;
         });
 
         it('should contain a value object', () => {

--- a/utils/answer.js
+++ b/utils/answer.js
@@ -1,7 +1,8 @@
 const answer = {
     YES: 'yes',
     NO: 'no',
-    NOT_PROVIDED: 'Not provided'
+    NOT_PROVIDED: 'Not provided',
+    NOT_REQUIRED: 'Not required'
 };
 
 module.exports = answer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@hmcts/look-and-feel@^1.8.0-1":
-  version "1.8.0-1"
-  resolved "https://registry.yarnpkg.com/@hmcts/look-and-feel/-/look-and-feel-1.8.0-1.tgz#6ec127f86c0fc6d80b6ab35e805baa8c25ef83fc"
+"@hmcts/look-and-feel@^1.8.0-3":
+  version "1.8.0-3"
+  resolved "https://registry.yarnpkg.com/@hmcts/look-and-feel/-/look-and-feel-1.8.0-3.tgz#9001f4463c8524e8a41325cb63cfcdaf6ca2fbd8"
   dependencies:
     babel-core "^6.26.0"
     babel-loader "^7.1.2"


### PR DESCRIPTION
* We can now test for values within CYA via CSS selectors.
* Defined a CSS selector file to prevent duplication of selectors.
* Hide some fields from CYA inline with the CYA prototype.
* Updated both unit & end-to-end tests.