### PR TITLE
SSCS-2447 Cookie-banner always displaying

### DIFF
--- a/steps/start/benefit-type/template.html
+++ b/steps/start/benefit-type/template.html
@@ -4,7 +4,7 @@
 
 {% block head -%}
     <link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
-    <script src="{{ asset_path }}main.js" type="text/javascript" />
+    <script src="{{ asset_path }}main.js" type="text/javascript"></script>
 {% endblock %}
 
 {% block page_title %}{{ content.titleHead }}{% endblock %}


### PR DESCRIPTION
- Add missed script closing tag in html.
- Was causing a bug where the cookie-banner would always display in the benefit-type page