### PR TITLE
Added a smoke test that completes a full journey from start to end

### DIFF
--- a/steps/hearing/arrangements/HearingArrangements.js
+++ b/steps/hearing/arrangements/HearingArrangements.js
@@ -55,11 +55,10 @@ class HearingArrangements extends Question {
             answer(this, {
                 question: this.content.cya.anythingElse.question,
                 section: sections.hearingArrangements,
-                answer: this.fields.anythingElse.value === '' ? 'Not required' : this.fields.anythingElse.value
+                answer: this.fields.anythingElse.value ? this.fields.anythingElse.value : 'Not required'
             })
         ];
     }
-
 
     values() {
 

--- a/test/e2e/page-objects/cya/submitAppeal.js
+++ b/test/e2e/page-objects/cya/submitAppeal.js
@@ -1,0 +1,11 @@
+'use strict';
+
+function signAndSubmit(name) {
+
+    const I = this;
+
+    I.fillField('#signer', name);
+    I.click('Submit');
+}
+
+module.exports = { signAndSubmit };

--- a/test/e2e/smoke/appeal.test.js
+++ b/test/e2e/smoke/appeal.test.js
@@ -27,6 +27,7 @@ Scenario('Appellant full journey from \'/start-an-appeal\' to the \'/confirmatio
     I.see(appellant.contactDetails.phoneNumber, appellantPhoneNumberAnswer);
     I.see(formatMobileNumber(appellant.contactDetails.phoneNumber), textMsgRemindersMobileAnswer);
     I.signAndSubmit(`${appellant.firstName} ${appellant.lastName}`);
+    I.wait(2);
     I.seeCurrentUrlEquals(paths.confirmation);
 
 });

--- a/test/e2e/smoke/appeal.test.js
+++ b/test/e2e/smoke/appeal.test.js
@@ -1,0 +1,32 @@
+const { formatMobileNumber } = require('utils/stringUtils');
+const startAnAppealContent = require('landing-pages/start-an-appeal/content.en');
+const doYouWantTextMsgReminders = require('steps/sms-notify/text-reminders/content.en').fields.doYouWantTextMsgReminders;
+
+const paths = require('paths');
+const data = require('test/e2e/data');
+const appellant = data.appellant;
+
+const selectors = require('steps/check-your-appeal/selectors');
+const appellantPhoneNumberAnswer   = `${selectors.appellant.phoneNumber} ${selectors.answer}`;
+const textMsgRemindersMobileAnswer = `${selectors.textMsgReminders.mobileNumber} ${selectors.answer}`;
+
+Feature('Full Journey');
+
+Scenario('Appellant full journey from \'/start-an-appeal\' to the \'/confirmation\' page @smoke', (I) => {
+
+    I.amOnPage(paths.landingPages.startAnAppeal);
+    I.click(startAnAppealContent.start);
+    I.enterDetailsFromStartToNINO();
+    I.enterAppellantContactDetailsWithMobileAndContinue(appellant.contactDetails.phoneNumber);
+    I.checkOptionAndContinue(doYouWantTextMsgReminders.yes);
+    I.checkOptionAndContinue('#useSameNumber-yes');
+    I.readSMSConfirmationAndContinue();
+    I.enterDetailsFromNoRepresentativeToSendingEvidence();
+    I.enterDetailsFromAttendingTheHearingToEnd();
+    I.confirmDetailsArePresent();
+    I.see(appellant.contactDetails.phoneNumber, appellantPhoneNumberAnswer);
+    I.see(formatMobileNumber(appellant.contactDetails.phoneNumber), textMsgRemindersMobileAnswer);
+    I.signAndSubmit(`${appellant.firstName} ${appellant.lastName}`);
+    I.seeCurrentUrlEquals(paths.confirmation);
+
+});


### PR DESCRIPTION
The details of the journey are defined here: 

```
/start-an-appeal
/benefit-type
/postcode-check
/independence
/have-a-mrn
/dwp-issuing-office
/mrn-date
/are-you-an-appointee
/enter-appellant-name
/enter-appellant-dob
/enter-appellant-nino
/enter-appellant-contact-details
/appellant-text-reminders
/send-to-number
/sms-confirmation
/representative
/reason-for-appealing
/other-reason-for-appealing
/sending-evidence
/the-hearing
/hearing-support
/hearing-arrangements
/hearing-availability
/dates-cant-attend
/dates-cant-attend/item-0
/dates-cant-attend
/check-your-appeal
/confirmation
```