### PR TITLE
Sonar-scan improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:coverage": "cross-env NODE_PATH=. NODE_ENV=test istanbul cover _mocha 'test/unit/**/*.test.js' --dir test/unit/coverage/html",
     "test:nsp": "nsp check",
     "test:a11y": "echo 'a11y tests not implemented'",
-    "sonar-scan": "sonar-scanner -Dsonar.projectName='SSCS :: Submit Your Appeal frontend' -Dsonar.projectKey='SSCSSYAF' -Dsonar.sources=. -Dsonar.exclusions=node_modules/**,test/**,assets/** -Dsonar.javascript.lcov.reportPaths=test/unit/coverage/html/lcov.info",
+    "sonar-scan": "sonar-scanner -Dsonar.projectName='SSCS :: Submit Your Appeal frontend' -Dsonar.projectKey='SSCSSYAF' -Dsonar.sources=. -Dsonar.exclusions=app.js,app-insights.js,server.js,node_modules/**,test/**,assets/** -Dsonar.javascript.lcov.reportPaths=test/unit/coverage/html/lcov.info",
     "health-check": "echo 'not implemented yet'"
   },
   "dependencies": {

--- a/test/unit/paths.test.js
+++ b/test/unit/paths.test.js
@@ -1,0 +1,10 @@
+const { expect } = require('test/util/chai');
+const paths = require('paths');
+
+describe('paths.js', () => {
+
+    it('should return an object', () => {
+        expect(paths).to.be.an('object');
+    });
+
+});

--- a/test/unit/steps.test.js
+++ b/test/unit/steps.test.js
@@ -1,0 +1,10 @@
+const { expect } = require('test/util/chai');
+const steps = require('steps');
+
+describe('steps.js', () => {
+
+    it('should return an array', () => {
+        expect(steps).to.be.an('array');
+    });
+
+});

--- a/test/unit/steps/check-your-appeal/sections.test.js
+++ b/test/unit/steps/check-your-appeal/sections.test.js
@@ -1,0 +1,10 @@
+const { expect } = require('test/util/chai');
+const sections = require('steps/check-your-appeal/sections');
+
+describe('sections.js', () => {
+
+    it('should return an object', () => {
+        expect(sections).to.be.an('object');
+    });
+
+});

--- a/test/unit/steps/check-your-appeal/selectors.test.js
+++ b/test/unit/steps/check-your-appeal/selectors.test.js
@@ -1,0 +1,10 @@
+const { expect } = require('test/util/chai');
+const selectors = require('steps/check-your-appeal/selectors');
+
+describe('steps.js', () => {
+
+    it('should return an object', () => {
+        expect(selectors).to.be.an('object');
+    });
+
+});


### PR DESCRIPTION
- Add `app.js`, `app-insights.js` and `server.js` to the sonar-scan exclusions
- Add basic unit tests for `paths.js`, `steps.js`, `sections.js`, `selectors.js`