### PR TITLE
SSCS-2781 Move appointee page

### DIFF
--- a/steps/compliance/mrn-date/MRNDate.js
+++ b/steps/compliance/mrn-date/MRNDate.js
@@ -69,7 +69,7 @@ class MRNDate extends Question {
         const isLessThanOrEqualToAMonth = DateUtils.isLessThanOrEqualToAMonth(mrnDate);
 
         return branch(
-            goTo(this.journey.steps.Appointee).if(isLessThanOrEqualToAMonth),
+            goTo(this.journey.steps.AppellantName).if(isLessThanOrEqualToAMonth),
             goTo(this.journey.steps.CheckMRN)
         );
     }

--- a/steps/compliance/mrn-over-month-late/MRNOverOneMonthLate.js
+++ b/steps/compliance/mrn-over-month-late/MRNOverOneMonthLate.js
@@ -50,7 +50,7 @@ class MRNOverOneMonthLate extends Question {
 
     next() {
 
-        return goTo(this.journey.steps.Appointee);
+        return goTo(this.journey.steps.AppellantName);
     }
 }
 

--- a/steps/compliance/mrn-over-thirteen-months-late/MRNOverThirteenMonthsLate.js
+++ b/steps/compliance/mrn-over-thirteen-months-late/MRNOverThirteenMonthsLate.js
@@ -50,7 +50,7 @@ class MRNOverThirteenMonthsLate extends Question {
 
     next() {
 
-        return goTo(this.journey.steps.Appointee);
+        return goTo(this.journey.steps.AppellantName);
     }
 }
 

--- a/steps/compliance/no-mrn/NoMRN.js
+++ b/steps/compliance/no-mrn/NoMRN.js
@@ -50,7 +50,7 @@ class NoMRN extends Question {
 
     next() {
 
-        return goTo(this.journey.steps.Appointee);
+        return goTo(this.journey.steps.AppellantName);
     }
 }
 

--- a/steps/identity/appointee/Appointee.js
+++ b/steps/identity/appointee/Appointee.js
@@ -50,7 +50,7 @@ class Appointee extends Question {
 
         return branch(
             goTo(this.journey.steps.AppealFormDownload).if(isAppointee),
-            goTo(this.journey.steps.AppellantName)
+            goTo(this.journey.steps.Independence)
         );
     }
 }

--- a/steps/start/postcode-checker/PostcodeChecker.js
+++ b/steps/start/postcode-checker/PostcodeChecker.js
@@ -49,7 +49,7 @@ class PostcodeChecker extends Question {
         const isPostcodeOnList = () => postcodeList.includes(outcode.toUpperCase());
 
         return branch(
-            goTo(this.journey.steps.Independence).if(isPostcodeOnList),
+            goTo(this.journey.steps.Appointee).if(isPostcodeOnList),
             goTo(this.journey.steps.InvalidPostcode)
         );
     }

--- a/test/e2e/codecept.conf.js
+++ b/test/e2e/codecept.conf.js
@@ -12,8 +12,8 @@ exports.config = {
             'show': false,
             'windowSize': ' 800x1000',
             'switches': {
-                            'ignore-certificate-errors': true
-                        }
+                'ignore-certificate-errors': true
+            }
         }
     },
     'include': {

--- a/test/e2e/journeys/datesCantAttend.test.js
+++ b/test/e2e/journeys/datesCantAttend.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const doYouWantTextMsgReminders = require('steps/sms-notify/text-reminders/content.en.json').fields.doYouWantTextMsgReminders;
+const DateUtils = require('utils/DateUtils');
 const moment = require('moment');
 const paths = require('paths');
 
@@ -21,35 +22,36 @@ After((I) => {
 
 Scenario('Appellant provides date of when they cannot attend the hearing', (I) => {
 
+    const randomWeekDay = DateUtils.getRandomWeekDayFromDate(moment().add(5, 'weeks'));
+
     I.enterDetailsFromStartToNINO();
     I.enterAppellantContactDetailsAndContinue();
     I.selectDoYouWantToReceiveTextMessageReminders(doYouWantTextMsgReminders.no);
     I.enterDetailsFromNoRepresentativeToSendingEvidence();
-    I.enterDetailsFromAttendingTheHearingToEnd();
-
+    I.enterDetailsFromAttendingTheHearingToEnd(randomWeekDay);
     I.confirmDetailsArePresent();
-    I.see(moment().add(10, 'weeks').format('DD MMMM YYYY'), datesYouCantAttendHearingAnswer);
+    I.see(randomWeekDay.format('DD MMMM YYYY'), datesYouCantAttendHearingAnswer);
 
 });
 
 Scenario('Appellant provides a single date for when they cannot attend the hearing and later edits it', (I) => {
 
-    const tenWeeksFromNow    = moment().add(10, 'weeks');
-    const elevenWeeksFromNow = moment().add(11, 'weeks');
+    const randomWeekDayIn5Weeks = DateUtils.getRandomWeekDayFromDate(moment().add(5, 'weeks'));
+    const randomWeekDayIn6Weeks = DateUtils.getRandomWeekDayFromDate(moment().add(6, 'weeks'));
 
     I.enterDetailsFromStartToNINO();
     I.enterAppellantContactDetailsAndContinue();
     I.selectDoYouWantToReceiveTextMessageReminders(doYouWantTextMsgReminders.no);
     I.enterDetailsFromNoRepresentativeToSendingEvidence();
-    I.enterDetailsFromAttendingTheHearingToEnd();
-    I.see(tenWeeksFromNow.format('DD MMMM YYYY'), datesYouCantAttendHearingAnswer);
+    I.enterDetailsFromAttendingTheHearingToEnd(randomWeekDayIn5Weeks);
+    I.see(randomWeekDayIn5Weeks.format('DD MMMM YYYY'), datesYouCantAttendHearingAnswer);
 
     // Now edit the single date from 10 to 11 weeks.
     I.click('Change', datesYouCantAttendHearingChange);
     I.seeCurrentUrlEquals(paths.hearing.hearingAvailability);
     I.click('Continue');
-    I.enterDateCantAttendAndContinue(elevenWeeksFromNow, 'Edit');
+    I.enterDateCantAttendAndContinue(randomWeekDayIn6Weeks, 'Edit');
     I.click('Continue');
-    I.see(elevenWeeksFromNow.format('DD MMMM YYYY'), datesYouCantAttendHearingAnswer);
+    I.see(randomWeekDayIn6Weeks.format('DD MMMM YYYY'), datesYouCantAttendHearingAnswer);
 
 });

--- a/test/e2e/journeys/mrnLate.test.js
+++ b/test/e2e/journeys/mrnLate.test.js
@@ -28,13 +28,13 @@ After((I) => {
 
         I.enterBenefitTypeAndContinue(data.benefitType.code);
         I.enterPostcodeAndContinue(data.appellant.contactDetails.postCode);
+        I.checkOptionAndContinue(isAppointee.no);
         I.continueFromIndependance();
         I.checkOptionAndContinue(haveAMRN.yes);
         I.enterDWPIssuingOfficeAndContinue(data.mrn.dwpIssuingOffice);
         I.enterAnMRNDateAndContinue(obj.mrnDate);
         I.checkOptionAndContinue(checkMRN.yes);
         I.enterReasonsForBeingLateAndContinue(data.mrn.reasonWhyMRNisLate);
-        I.checkOptionAndContinue(isAppointee.no);
         I.enterAppellantNameAndContinue(appellant.title, appellant.firstName, appellant.lastName);
         I.enterAppellantDOBAndContinue(appellant.dob.day, appellant.dob.month, appellant.dob.year);
         I.enterAppellantNINOAndContinue(appellant.nino);

--- a/test/e2e/journeys/noMRN.test.js
+++ b/test/e2e/journeys/noMRN.test.js
@@ -6,6 +6,8 @@ const isAppointee = require('steps/identity/appointee/content.en.json').fields.i
 const doYouWantTextMsgReminders = require('steps/sms-notify/text-reminders/content.en.json').fields.doYouWantTextMsgReminders;
 const contactDWP = require('steps/compliance/contact-dwp/content.en');
 
+const DateUtils = require('utils/DateUtils');
+const moment = require('moment');
 const data = require('test/e2e/data');
 const appellant = data.appellant;
 
@@ -24,6 +26,8 @@ After((I) => {
 
 Scenario('Appellant has contacted DWP', (I) => {
 
+    const randomWeekDay = DateUtils.getRandomWeekDayFromDate(moment().add(5, 'weeks'));
+
     const hasMRN = false;
 
     I.enterBenefitTypeAndContinue(data.benefitType.code);
@@ -39,7 +43,7 @@ Scenario('Appellant has contacted DWP', (I) => {
     I.enterAppellantContactDetailsAndContinue();
     I.selectDoYouWantToReceiveTextMessageReminders(doYouWantTextMsgReminders.no);
     I.enterDetailsFromNoRepresentativeToSendingEvidence();
-    I.enterDetailsFromAttendingTheHearingToEnd();
+    I.enterDetailsFromAttendingTheHearingToEnd(randomWeekDay);
     I.confirmDetailsArePresent(hasMRN);
 
 });

--- a/test/e2e/journeys/noMRN.test.js
+++ b/test/e2e/journeys/noMRN.test.js
@@ -28,11 +28,11 @@ Scenario('Appellant has contacted DWP', (I) => {
 
     I.enterBenefitTypeAndContinue(data.benefitType.code);
     I.enterPostcodeAndContinue(appellant.contactDetails.postCode);
+    I.checkOptionAndContinue(isAppointee.no);
     I.continueFromIndependance();
     I.checkOptionAndContinue(haveAMRN.no);
     I.checkOptionAndContinue(haveContactedDWP.yes);
     I.enterReasonForNoMRNAndContinue(data.mrn.reasonForNoMRN);
-    I.checkOptionAndContinue(isAppointee.no);
     I.enterAppellantNameAndContinue(appellant.title, appellant.firstName, appellant.lastName);
     I.enterAppellantDOBAndContinue(appellant.dob.day, appellant.dob.month, appellant.dob.year);
     I.enterAppellantNINOAndContinue(appellant.nino);
@@ -48,6 +48,7 @@ Scenario('Appellant has not contacted DWP and exits the service', (I) => {
 
     I.enterBenefitTypeAndContinue(data.benefitType.code);
     I.enterPostcodeAndContinue(appellant.contactDetails.postCode);
+    I.checkOptionAndContinue(isAppointee.no);
     I.continueFromIndependance();
     I.selectHaveYouGotAMRNAndContinue(haveAMRN.no);
     I.checkOptionAndContinue(haveContactedDWP.no);

--- a/test/e2e/page-objects/cya/checkYourAppeal.js
+++ b/test/e2e/page-objects/cya/checkYourAppeal.js
@@ -20,11 +20,11 @@ function enterDetailsFromStartToNINO() {
 
     I.enterBenefitTypeAndContinue(data.benefitType.code);
     I.enterPostcodeAndContinue(appellant.contactDetails.postCode);
+    I.selectAreYouAnAppointeeAndContinue(appointeeContent.fields.isAppointee.no);
     I.continueFromIndependance();
     I.selectHaveYouGotAMRNAndContinue(haveAMRNContent.fields.haveAMRN.yes);
     I.enterDWPIssuingOfficeAndContinue(data.mrn.dwpIssuingOffice);
     I.enterAnMRNDateAndContinue(oneMonthAgo);
-    I.selectAreYouAnAppointeeAndContinue(appointeeContent.fields.isAppointee.no);
     I.enterAppellantNameAndContinue(appellant.title, appellant.firstName, appellant.lastName);
     I.enterAppellantDOBAndContinue(appellant.dob.day, appellant.dob.month, appellant.dob.year);
     I.enterAppellantNINOAndContinue(appellant.nino);

--- a/test/e2e/page-objects/cya/checkYourAppeal.js
+++ b/test/e2e/page-objects/cya/checkYourAppeal.js
@@ -9,7 +9,6 @@ const datesCantAttendContent = require('steps/hearing/dates-cant-attend/content.
 const reasonsForAppealingContent = require('steps/reasons-for-appealing/reason-for-appealing/content.en');
 const oneMonthAgo = DateUtils.oneMonthAgo();
 const selectors = require('steps/check-your-appeal/selectors');
-const moment = require('moment');
 const paths = require('paths');
 const data = require('test/e2e/data');
 const appellant = data.appellant;
@@ -52,7 +51,7 @@ function enterDetailsFromNoRepresentativeToEnd() {
 
 }
 
-function enterDetailsFromAttendingTheHearingToEnd() {
+function enterDetailsFromAttendingTheHearingToEnd(date) {
 
     const I = this;
 
@@ -60,7 +59,7 @@ function enterDetailsFromAttendingTheHearingToEnd() {
     I.selectDoYouNeedSupportAndContinue(supportContent.fields.arrangements.yes);
     I.checkAllArrangementsAndContinue();
     I.selectHearingAvailabilityAndContinue(availabilityContent.fields.scheduleHearing.yes);
-    I.enterDateCantAttendAndContinue(moment().add(10, 'weeks'), datesCantAttendContent.links.add);
+    I.enterDateCantAttendAndContinue(date, datesCantAttendContent.links.add);
     I.click('Continue');
 
 }

--- a/test/e2e/page/compliance/mrnDate.test.js
+++ b/test/e2e/page/compliance/mrnDate.test.js
@@ -17,14 +17,14 @@ After((I) => {
 Scenario('I have an MRN dated one day short of a month ago', (I) => {
 
     I.enterAnMRNDateAndContinue(DateUtils.oneDayShortOfAMonthAgo());
-    I.seeCurrentUrlEquals(paths.identity.areYouAnAppointee);
+    I.seeCurrentUrlEquals(paths.identity.enterAppellantName);
 
 });
 
 Scenario('I have an MRN dated one month ago', (I) => {
 
     I.enterAnMRNDateAndContinue(DateUtils.oneMonthAgo());
-    I.seeCurrentUrlEquals(paths.identity.areYouAnAppointee);
+    I.seeCurrentUrlEquals(paths.identity.enterAppellantName);
 
 });
 

--- a/test/e2e/page/compliance/mrnOverOneMonthLate.test.js
+++ b/test/e2e/page/compliance/mrnOverOneMonthLate.test.js
@@ -14,11 +14,11 @@ After((I) => {
     I.endTheSession();
 });
 
-Scenario('When I enter a reason for lateness and click continue, I am taken to the no mrn page', (I) => {
+Scenario('When I enter a reason for lateness and click continue, I am taken to the enter-appellant-name page', (I) => {
 
     I.fillField('#reasonForBeingLate', 'Late');
     I.click('Continue');
-    I.seeInCurrentUrl(paths.identity.areYouAnAppointee);
+    I.seeInCurrentUrl(paths.identity.enterAppellantName);
 
 });
 

--- a/test/e2e/page/compliance/mrnOverThirteenMonthsLate.test.js
+++ b/test/e2e/page/compliance/mrnOverThirteenMonthsLate.test.js
@@ -14,11 +14,11 @@ After((I) => {
     I.endTheSession();
 });
 
-Scenario('When I enter a reason for lateness and click continue, I am taken to the are-you-an-appointee page', (I) => {
+Scenario('When I enter a reason for lateness and click continue, I am taken to the enter-appellant-name page', (I) => {
 
     I.fillField('#reasonForBeingLate', 'Late');
     I.click('Continue');
-    I.seeInCurrentUrl(paths.identity.areYouAnAppointee);
+    I.seeInCurrentUrl(paths.identity.enterAppellantName);
 
 });
 

--- a/test/e2e/page/hearing/datesCantAttend.test.js
+++ b/test/e2e/page/hearing/datesCantAttend.test.js
@@ -3,8 +3,9 @@
 const content = require('steps/hearing/dates-cant-attend/content.en');
 const paths = require('paths');
 const moment = require('moment');
-const validDate = moment().add(5, 'weeks');
-const additionalValidDate = moment().add(10, 'weeks');
+const DateUtils = require('utils/DateUtils');
+const validDate = DateUtils.getRandomWeekDayFromDate(moment().add(5, 'weeks'));
+const additionalValidDate = DateUtils.getRandomWeekDayFromDate(moment().add(10, 'weeks'));
 
 Feature('Dates can\'t attend');
 

--- a/test/e2e/page/identity/appointee.test.js
+++ b/test/e2e/page/identity/appointee.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const appellantName = require('steps/identity/appellant-name/content.en.json');
+const independence = require('steps/start/independence/content.en.json');
 const appealFormDownload = require('steps/appeal-form-download/content.en.json');
 const appointee = require('steps/identity/appointee/content.en');
 const paths = require('paths');
@@ -24,10 +24,10 @@ Scenario('When I select Yes, I am taken to the download appointee form page', (I
 
 });
 
-Scenario('When I select No, I am taken to the enter your details page', (I) => {
+Scenario('When I select No, I am taken to the independence page', (I) => {
 
     I.selectAreYouAnAppointeeAndContinue(appointee.fields.isAppointee.no);
-    I.seeInCurrentUrl(paths.identity.enterAppellantName);
-    I.see(appellantName.title);
+    I.seeInCurrentUrl(paths.start.independence);
+    I.see(independence.title);
 
 });

--- a/test/e2e/page/start/enterPostcode.test.js
+++ b/test/e2e/page/start/enterPostcode.test.js
@@ -16,11 +16,11 @@ Scenario('When I go to the enter postcode page I see the page heading', (I) => {
 
 });
 
-Scenario('When I enter a valid postcode that is on the list, I go to the Independence page', (I) => {
+Scenario('When I enter a valid postcode that is on the list, I go to the are-you-an-appointee page', (I) => {
 
     I.fillField('#postcode', 'WV11 2HE');
     I.click('Continue');
-    I.seeInCurrentUrl(paths.start.independence);
+    I.seeInCurrentUrl(paths.identity.areYouAnAppointee);
 
 });
 

--- a/test/e2e/smoke/appeal.test.js
+++ b/test/e2e/smoke/appeal.test.js
@@ -1,6 +1,8 @@
 const { formatMobileNumber } = require('utils/stringUtils');
 const startAnAppealContent = require('landing-pages/start-an-appeal/content.en');
 const doYouWantTextMsgReminders = require('steps/sms-notify/text-reminders/content.en').fields.doYouWantTextMsgReminders;
+const DateUtils = require('utils/DateUtils');
+const moment = require('moment');
 
 const paths = require('paths');
 const data = require('test/e2e/data');
@@ -14,6 +16,8 @@ Feature('Full Journey');
 
 Scenario('Appellant full journey from \'/start-an-appeal\' to the \'/confirmation\' page @smoke', (I) => {
 
+    const randomWeekDay = DateUtils.getRandomWeekDayFromDate(moment().add(5, 'weeks'));
+
     I.amOnPage(paths.landingPages.startAnAppeal);
     I.click(startAnAppealContent.start);
     I.enterDetailsFromStartToNINO();
@@ -22,7 +26,7 @@ Scenario('Appellant full journey from \'/start-an-appeal\' to the \'/confirmatio
     I.checkOptionAndContinue('#useSameNumber-yes');
     I.readSMSConfirmationAndContinue();
     I.enterDetailsFromNoRepresentativeToSendingEvidence();
-    I.enterDetailsFromAttendingTheHearingToEnd();
+    I.enterDetailsFromAttendingTheHearingToEnd(randomWeekDay);
     I.confirmDetailsArePresent();
     I.see(formatMobileNumber(appellant.contactDetails.phoneNumber), appellantPhoneNumberAnswer);
     I.see(formatMobileNumber(appellant.contactDetails.phoneNumber), textMsgRemindersMobileAnswer);

--- a/test/unit/steps/compliance/mrn-date/MRNDate.test.js
+++ b/test/unit/steps/compliance/mrn-date/MRNDate.test.js
@@ -16,7 +16,7 @@ describe('MRNDate.js', () => {
         mrnDate = new MRNDate({
             journey: {
                 steps: {
-                    Appointee: paths.identity.areYouAnAppointee,
+                    AppellantName: paths.identity.enterAppellantName,
                     CheckMRN:  paths.compliance.checkMRNDate
                 }
             }
@@ -109,14 +109,14 @@ describe('MRNDate.js', () => {
             mrnDate.fields.mrnDate.value = date
         };
 
-        it('returns the next step path /are-you-an-appointee if date less than a month', () => {
+        it('returns the next step path /enter-appellant-name if date less than a month', () => {
             setMRNDate(DateUtils.oneDayShortOfAMonthAgo());
-            expect(mrnDate.next().step).to.eql(paths.identity.areYouAnAppointee);
+            expect(mrnDate.next().step).to.eql(paths.identity.enterAppellantName);
         });
 
-        it('returns the next step path /are-you-an-appointee if date is equal to a month', () => {
+        it('returns the next step path /enter-appellant-name if date is equal to a month', () => {
             setMRNDate(DateUtils.oneMonthAgo());
-            expect(mrnDate.next().step).to.eql(paths.identity.areYouAnAppointee);
+            expect(mrnDate.next().step).to.eql(paths.identity.enterAppellantName);
         });
 
         it('returns the next step path /check-mrn-date if date more than a month', () => {

--- a/test/unit/steps/compliance/mrn-over-month-late/MRNOverOneMonthLate.test.js
+++ b/test/unit/steps/compliance/mrn-over-month-late/MRNOverOneMonthLate.test.js
@@ -14,7 +14,7 @@ describe('MRNOverOneMonth.js', () => {
         mrnOverOneMonth = new MRNOverOneMonthLate({
             journey: {
                 steps: {
-                    Appointee: paths.identity.areYouAnAppointee
+                    AppellantName: paths.identity.enterAppellantName
                 }
             }
         });
@@ -99,8 +99,8 @@ describe('MRNOverOneMonth.js', () => {
 
     describe('next()', () => {
 
-        it('returns the next step path /are-you-an-appointee', () => {
-            expect(mrnOverOneMonth.next()).to.eql({ nextStep: paths.identity.areYouAnAppointee });
+        it('returns the next step path /enter-appellant-name', () => {
+            expect(mrnOverOneMonth.next()).to.eql({ nextStep: paths.identity.enterAppellantName });
         });
 
     });

--- a/test/unit/steps/compliance/mrn-over-thirteen-months-late/MRNOverThirteenMonthsLate.test.js
+++ b/test/unit/steps/compliance/mrn-over-thirteen-months-late/MRNOverThirteenMonthsLate.test.js
@@ -14,7 +14,7 @@ describe('MRNOverThirteenMonthsLate.js', () => {
         mrnOverThirteenMonthsLate = new MRNOverThirteenMonthsLate({
             journey: {
                 steps: {
-                    Appointee: paths.identity.areYouAnAppointee
+                    AppellantName: paths.identity.enterAppellantName
                 }
             }
         });
@@ -100,8 +100,8 @@ describe('MRNOverThirteenMonthsLate.js', () => {
 
     describe('next()', () => {
 
-        it('returns the next step path /are-you-an-appointee', () => {
-            expect(mrnOverThirteenMonthsLate.next()).to.eql({ nextStep: paths.identity.areYouAnAppointee });
+        it('returns the next step path /enter-appellant-name', () => {
+            expect(mrnOverThirteenMonthsLate.next()).to.eql({ nextStep: paths.identity.enterAppellantName });
         });
 
     });

--- a/test/unit/steps/compliance/no-mrn/NoMRN.test.js
+++ b/test/unit/steps/compliance/no-mrn/NoMRN.test.js
@@ -14,7 +14,7 @@ describe('NoMRN.js', () => {
         noMRN = new NoMRN({
             journey: {
                 steps: {
-                    Appointee: '/are-you-an-appointee'
+                    AppellantName: paths.identity.enterAppellantName
                 }
             }
         });
@@ -100,8 +100,8 @@ describe('NoMRN.js', () => {
 
     describe('next()', () => {
 
-        it('returns the next step path /are-you-an-appointee', () => {
-            expect(noMRN.next()).to.eql({ nextStep: '/are-you-an-appointee' });
+        it('returns the next step path /enter-appellant-name', () => {
+            expect(noMRN.next()).to.eql({ nextStep: paths.identity.enterAppellantName });
         });
 
     });

--- a/test/unit/steps/identity/appointee/Appointee.test.js
+++ b/test/unit/steps/identity/appointee/Appointee.test.js
@@ -15,7 +15,7 @@ describe('Appointee.js', () => {
         appointee = new Appointee({
             journey: {
                 steps: {
-                    AppellantName: paths.identity.enterAppellantName,
+                    Independence: paths.start.independence,
                     AppealFormDownload: paths.appealFormDownload
                 }
             }
@@ -126,10 +126,10 @@ describe('Appointee.js', () => {
             expect(nextStep).to.eq(paths.appealFormDownload);
         });
 
-        it('returns the next step path /enter-appellant-name', () => {
+        it('returns the next step path /independence', () => {
             appointee.fields.isAppointee.value = userAnswer.NO;
             const nextStep = appointee.next().fallback.nextStep;
-            expect(nextStep).to.eq(paths.identity.enterAppellantName);
+            expect(nextStep).to.eq(paths.start.independence);
         });
 
     });

--- a/test/unit/steps/start/PostcodeChecker.test.js
+++ b/test/unit/steps/start/PostcodeChecker.test.js
@@ -13,7 +13,7 @@ describe('PostcodeChecker.js', () => {
         postcodeChecker = new PostcodeChecker({
             journey: {
                 steps: {
-                    Independence: paths.start.independence,
+                    Appointee: paths.identity.areYouAnAppointee,
                     InvalidPostcode: paths.start.invalidPostcode
                 }
             }
@@ -87,9 +87,9 @@ describe('PostcodeChecker.js', () => {
 
     describe('next()', () => {
 
-        it('returns the next step path /independence if postcode is on the list of acceptable postcodes', () => {
+        it('returns the next step path /are-you-an-appointee if postcode is on the list of acceptable postcodes', () => {
             postcodeChecker.fields.postcode.value = 'WV11 2HE';
-            expect(postcodeChecker.next().step).to.eql(paths.start.independence);
+            expect(postcodeChecker.next().step).to.eql(paths.identity.areYouAnAppointee);
         });
 
         it('returns the next step path /invalid-postcode if postcode is not on the list of acceptable postcodes', () => {

--- a/test/unit/utils/DateUtils.test.js
+++ b/test/unit/utils/DateUtils.test.js
@@ -273,4 +273,25 @@ describe('DateUtils.js', () => {
 
     });
 
+    describe('getRandomWeekDayFromDate', () => {
+
+        const weeks = 12;
+
+        for (let i = 1; i <= weeks; i++) {
+
+            it(`should select a random day of the week when the date is ${i} weeks time`, () => {
+                const date = moment().add(i, 'week');
+                const weekday = DateUtils.getRandomWeekDayFromDate(date);
+                expect(DateUtils.isDateOnTheWeekend(weekday)).to.equal(false);
+            });
+
+            it(`should select a random day of the week when the date is ${i} months time`, () => {
+                const date = moment().add(i, 'month');
+                const weekday = DateUtils.getRandomWeekDayFromDate(date);
+                expect(DateUtils.isDateOnTheWeekend(weekday)).to.equal(false);
+            });
+        }
+
+    });
+
 });

--- a/utils/DateUtils.js
+++ b/utils/DateUtils.js
@@ -67,6 +67,14 @@ class DateUtils {
         return date.weekday() === 0 || date.weekday() === 6
     }
 
+    static getRandomWeekDayFromDate(date) {
+        return date.clone().weekday(DateUtils.getRandomInt(1, 5));
+    }
+
+    static getRandomInt(min, max) {
+        return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
+
 }
 
 module.exports = DateUtils;


### PR DESCRIPTION
- Move the appointee page to after the postcode-check page in order to throw those users out of the form earlier in the journey
- Change the next pages for `/postcode-check`, `/are-you-an-appointee`, `/mrn-date`, `/mrn-over-month-late`, `/mrn-over-thirteen-months-late`, `/no-mrn`
- Update the unit tests
- Update the e2e tests