### PR TITLE
SSCS-2805 Trailing whitespace on name fields

### DIFF
--- a/steps/check-your-appeal/CheckYourAppeal.js
+++ b/steps/check-your-appeal/CheckYourAppeal.js
@@ -68,7 +68,7 @@ class CheckYourAppeal extends CYA {
 
             textField('signer').joi(
                 this.content.fields.signer.error.required,
-                Joi.string().regex(lastName).required())
+                Joi.string().regex(lastName).trim().required())
         );
     }
 

--- a/steps/identity/appellant-name/AppellantName.js
+++ b/steps/identity/appellant-name/AppellantName.js
@@ -27,11 +27,11 @@ class AppellantName extends Question {
 
             textField('firstName')
                 .joi(fields.firstName.error.required, Joi.string().required())
-                .joi(fields.firstName.error.invalid, Joi.string().regex(firstName)),
+                .joi(fields.firstName.error.invalid, Joi.string().trim().regex(firstName)),
 
             textField('lastName')
                 .joi(fields.lastName.error.required, Joi.string().required())
-                .joi(fields.lastName.error.invalid, Joi.string().regex(lastName))
+                .joi(fields.lastName.error.invalid, Joi.string().trim().regex(lastName))
         );
     }
 

--- a/steps/representative/representative-details/RepresentativeDetails.js
+++ b/steps/representative/representative-details/RepresentativeDetails.js
@@ -25,12 +25,12 @@ class RepresentativeDetails extends Question {
 
             textField('firstName')
                 .joi(fields.firstName.error.required, Joi.string().required())
-                .joi(fields.firstName.error.invalid, Joi.string().regex(firstName)
+                .joi(fields.firstName.error.invalid, Joi.string().trim().regex(firstName)
             ),
 
             textField('lastName')
                 .joi(fields.lastName.error.required, Joi.string().required())
-                .joi(fields.lastName.error.invalid, Joi.string().regex(lastName)
+                .joi(fields.lastName.error.invalid, Joi.string().trim().regex(lastName)
             ),
 
             textField('organisation').joi(


### PR DESCRIPTION
- Fix bug where when a name is entered with a space after, the validation would fail and display the error e.g. `Ben `

- Add `Joi().trim()` to the name fields for `appellant-name`, `rep-name` and `check-your-appeal` to remove the whitespace when validating