### PR TITLE
Reverting Codecept.js config settings to their defaults

### DIFF
--- a/test/e2e/codecept.conf.js
+++ b/test/e2e/codecept.conf.js
@@ -1,5 +1,5 @@
-const waitForTimeout = parseInt(process.env.E2E_WAIT_FOR_TIMEOUT_VALUE) || 10000;
-const waitForAction = parseInt(process.env.E2E_WAIT_FOR_ACTION_VALUE) || 2000;
+const waitForTimeout = parseInt(process.env.E2E_WAIT_FOR_TIMEOUT_VALUE) || 1000;
+const waitForAction  = parseInt(process.env.E2E_WAIT_FOR_ACTION_VALUE)  || 500;
 exports.config = {
     'tests': './**/*.test.js',
     'output': './output',
@@ -8,7 +8,6 @@ exports.config = {
         'Nightmare': {
             'url': process.env.E2E_FRONTEND_URL || 'http://localhost:3000',
             'waitForTimeout': waitForTimeout,
-            'typeInterval': 20,
             'waitForAction': waitForAction,
             'show': false,
             'windowSize': ' 800x1000'


### PR DESCRIPTION
Due to a previous commit: 547d1e793a7f2636ba6209c49889adf451a10b7c the time taken to run our functional tests has increased from 13 minutes to 40 minutes which is an increase of 207% - Great!

The current Nightmare.js default for waitForTimeout is 1000 this was
modified in the above commit to 10,000.

The current Nightmare.js default for waitForAction is 500 this was
modified in the above commit to 2000.

This commit reverts these values back to their defaults ensuring our tests run in a timely manner.