### PR TITLE
Public key pinning

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,8 +60,8 @@ app.use(helmet.contentSecurityPolicy({
 
 // Helmet HTTP public key pinning
 app.use(helmet.hpkp({
-    maxAge: 900,
-    sha256s: ['AbCdEf123=', 'XyzABC123=']
+    maxAge: config.ssl.hpkp.maxAge,
+    sha256s: config.ssl.hpkp.sha256s
 }));
 
 // Helmet referrer policy

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -11,6 +11,12 @@
     "useSSL": "USE_SSL"
   },
   "api": {
-    "url":  "TRIBUNALS_CASE_API_URL"
+    "url": "TRIBUNALS_CASE_API_URL"
+  },
+  "ssl": {
+    "hpkp": {
+     "maxAge": "TO_BE_DEFINED",
+     "sha256s": "TO_BE_DEFINED"
+    }
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -12,5 +12,11 @@
   },
   "api": {
     "url":  "http://localhost:8080"
+  },
+  "ssl": {
+    "hpkp": {
+      "maxAge": "3600",
+      "sha256s": ["AbCdEf123=", "ZyXwVu456="]
+    }
   }
 }


### PR DESCRIPTION
* **pin-sha256** - The quoted string is the Base64 encoded Subject Public
Key Information (SPKI) fingerprint. It is possible to specify multiple
pins for different public keys. Some browsers might allow other hashing
algorithms than SHA-256 in the future. See below on how to extract this
information out of a certificate or key file.

* **max-age** - The time, in seconds, that the browser should remember that
this site is only to be accessed using one of the defined keys.

Note: Helmet will take both SHA-256 hashes from the array and convert them into the following HTTP headers: `Public-Key-Pins: pin-sha256="AbCdEf123="; pin-sha256="ZyXwVu456="; max-age=3600`