### PR TITLE
Reasons for appeal no items error

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -126,12 +126,15 @@ label.form-label[for="signer"] {
 }
 
 .add-another-list div {
-  padding: 15px 0;
-  width: 100%;
-  border-bottom: 1px solid $border-colour;
 
-  &:first-child {
-    border-top: 1px solid $border-colour;
+  &:not(.noItems) {
+    padding: 15px 0;
+    width: 100%;
+    border-bottom: 1px solid $border-colour;
+
+    &:first-child {
+      border-top: 1px solid $border-colour;
+    }
   }
 
   .add-another-list-item {

--- a/steps/reasons-for-appealing/reason-for-appealing/template.html
+++ b/steps/reasons-for-appealing/reason-for-appealing/template.html
@@ -1,6 +1,6 @@
 {% extends "components/globals.html" %}
 {% extends "look-and-feel/layouts/add_another.html" %}
-{% from "look-and-feel/components/fields.njk" import textbox, formSection %}
+{% from "look-and-feel/components/fields.njk" import textbox, formSection, errorClass, errorsFor %}
 {% from "components/formElements.html" import textarea %}
 
 {% block page_title %}{{ content.titleHead }}{% endblock %}
@@ -17,6 +17,22 @@
     itemsListLabel: '',
     editItemLabel: content.itemLabel
 } %}
+
+{% block noItems %}
+    <div id="items" class="noItems {{ errorClass(fields.items) }}">
+
+        {% if fields.validated and not fields.valid %}
+            {%- for error in fields.errors -%}
+                <span class="error-message">
+                    {{ error.message }}
+                </span>
+            {%- endfor -%}
+        {% endif %}
+
+        {{ content.noReasons }}
+
+    </div>
+{% endblock %}
 
 {% block item %}
     {{ item.whatYouDisagreeWith.value }}


### PR DESCRIPTION
- Overwrite look and feel `noItems` block in order to add the error around the items list
- Error wraps the noItems div when trying to continue without adding a date
- Make it so clicking the error link scrolls down to the error
- Edit CSS for this

<img width="918" alt="screen shot 2018-03-05 at 17 05 22" src="https://user-images.githubusercontent.com/11047071/36988832-beff6ba2-2097-11e8-9cd2-d2a872f33f4f.png">

