### PR TITLE
Increase page timeout delay from 100ms to 2000ms

### DIFF
--- a/app.js
+++ b/app.js
@@ -148,7 +148,7 @@ journey(app, {
             message: content.errors.serverError.message
         }
     },
-    timeoutDelay: 100,
+    timeoutDelay: 2000,
     apiUrl: `${config.api.url}/appeals`
 });
 


### PR DESCRIPTION
* If a page fails to load for whatever reason the user will have to wait 2000ms before being notified.