### PR TITLE
SSCS-2864 Leading and trailing white space for validation

### DIFF
--- a/steps/compliance/dwp-issuing-office/DWPIssuingOffice.js
+++ b/steps/compliance/dwp-issuing-office/DWPIssuingOffice.js
@@ -27,11 +27,11 @@ class DWPIssuingOffice extends Question {
 
                 .joi(
                     this.content.fields.pipNumber.error.notNumeric,
-                    Joi.string().regex(numbers))
+                    Joi.string().trim().regex(numbers))
 
                 .joi(
                     this.content.fields.pipNumber.error.invalid,
-                    Joi.string().valid(officeIds)
+                    Joi.string().trim().valid(officeIds)
                 )
         });
     }

--- a/steps/identity/appellant-contact-details/AppellantContactDetails.js
+++ b/steps/identity/appellant-contact-details/AppellantContactDetails.js
@@ -47,7 +47,7 @@ class AppellantContactDetails extends Question {
             postCode: text
                 .joi(
                     fields.postCode.error.required,
-                    Joi.string().regex(postCode).required()
+                    Joi.string().trim().regex(postCode).required()
                 ),
             phoneNumber: text
                 .joi(
@@ -57,7 +57,7 @@ class AppellantContactDetails extends Question {
             emailAddress: text
                 .joi(
                     fields.emailAddress.error.invalid,
-                    Joi.string().email(emailOptions).allow('')
+                    Joi.string().trim().email(emailOptions).allow('')
                 ),
 
 

--- a/steps/representative/representative-details/RepresentativeDetails.js
+++ b/steps/representative/representative-details/RepresentativeDetails.js
@@ -67,12 +67,12 @@ class RepresentativeDetails extends Question {
             postCode: text
                 .joi(
                     fields.postCode.error.required,
-                    Joi.string().regex(postCode).required()
+                    Joi.string().trim().regex(postCode).required()
                 ),
             emailAddress: text
                 .joi(
                     fields.emailAddress.error.invalid,
-                    Joi.string().email(emailOptions).allow('')
+                    Joi.string().trim().email(emailOptions).allow('')
                 ),
             phoneNumber: text
                 .joi(

--- a/steps/start/postcode-checker/PostcodeChecker.js
+++ b/steps/start/postcode-checker/PostcodeChecker.js
@@ -25,7 +25,7 @@ class PostcodeChecker extends Question {
                     Joi.string().required()
                 ).joi(
                     this.content.fields.postcode.error.invalid,
-                    Joi.string().regex(postCode)
+                    Joi.string().trim().regex(postCode)
                 )
         });
     }


### PR DESCRIPTION
- Add `.trim()` to validation for fields that have whitespace validation error.
- DwpIssuingOffice: `pipNumber`,
- AppellantContactDetails: `postcode`, `emailAddress `,
- RepresentativeDetails: `postcode`, `emailAddress `,
- PostcodeChecker: `postcode`