### PR TITLE
SSCS-2450 Display Addresses in CYA

### DIFF
--- a/steps/identity/appellant-contact-details/AppellantContactDetails.js
+++ b/steps/identity/appellant-contact-details/AppellantContactDetails.js
@@ -18,6 +18,16 @@ class AppellantContactDetails extends Question {
         return paths.identity.enterAppellantContactDetails;
     }
 
+    get CYAPhoneNumber() {
+
+        return this.fields.phoneNumber.value ? formatMobileNumber(this.fields.phoneNumber.value) : userAnswer.NOT_PROVIDED;
+    }
+
+    get CYAEmailAddress() {
+
+        return this.fields.emailAddress.value || userAnswer.NOT_PROVIDED;
+    }
+
     get form() {
 
         const fields = this.content.fields;
@@ -69,46 +79,9 @@ class AppellantContactDetails extends Question {
         return [
 
             answer(this, {
-                question: this.content.cya.addressLine1.question,
                 section: sections.appellantDetails,
-                answer: this.fields.addressLine1.value
-            }),
-
-            answer(this, {
-                question: this.content.cya.addressLine2.question,
-                section: sections.appellantDetails,
-                answer: this.fields.addressLine2.value || userAnswer.NOT_PROVIDED
-            }),
-
-            answer(this, {
-                question: this.content.cya.townCity.question,
-                section: sections.appellantDetails,
-                answer: this.fields.townCity.value
-            }),
-
-            answer(this, {
-                question: this.content.cya.county.question,
-                section: sections.appellantDetails,
-                answer: this.fields.county.value
-            }),
-
-            answer(this, {
-                question: this.content.cya.postCode.question,
-                section: sections.appellantDetails,
-                answer: this.fields.postCode.value
-            }),
-
-            answer(this, {
-                question: this.content.cya.emailAddress.question,
-                section: sections.appellantDetails,
-                answer: this.fields.emailAddress.value || userAnswer.NOT_PROVIDED
-            }),
-
-            answer(this, {
-                question: this.content.cya.phoneNumber.question,
-                section: sections.appellantDetails,
-                answer: this.fields.phoneNumber.value ? formatMobileNumber(this.fields.phoneNumber.value) : userAnswer.NOT_PROVIDED
-            }),
+                template: 'answer.html'
+            })
         ];
     }
 

--- a/steps/identity/appellant-contact-details/answer.html
+++ b/steps/identity/appellant-contact-details/answer.html
@@ -1,0 +1,21 @@
+<dl class="cya-whatYouDisagreeWith">
+    <dt class="cya-question">{{ content.cya.address.question }}</dt>
+    <dd class="cya-answer">
+        {{ fields.addressLine1.value }}<br>
+        {% if fields.addressLine2.value %}{{ fields.addressLine2.value }}<br>{% endif %}
+        {{ fields.townCity.value }}<br>
+        {{ fields.county.value }}<br>
+        {{ fields.postCode.value }}<br>
+    </dd>
+    <dd class="cya-change"><a href="{{ path }}">{{ content.cya.change }}</a></dd>
+</dl>
+<dl id="cya-appellantcontactdetails-email-address" class="cya-whatYouDisagreeWith">
+    <dt class="cya-question">{{ content.cya.emailAddress.question }}</dt>
+    <dd class="cya-answer">{{ CYAEmailAddress }}</dd>
+    <dd class="cya-change"></dd>
+</dl>
+<dl id="cya-appellantcontactdetails-phone-number">
+    <dt class="cya-question ">{{ content.cya.phoneNumber.question }}</dt>
+    <dd class="cya-answer">{{ CYAPhoneNumber }}</dd>
+    <dd class="cya-change"></dd>
+</dl>

--- a/steps/identity/appellant-contact-details/content.en.json
+++ b/steps/identity/appellant-contact-details/content.en.json
@@ -49,26 +49,15 @@
     }
   },
   "cya": {
-    "addressLine1": {
-      "question": "Address line 1"
-    },
-    "addressLine2": {
-      "question": "Address line 2"
-    },
-    "townCity": {
-      "question": "Town/City"
-    },
-    "county": {
-      "question": "County"
-    },
-    "postCode": {
-      "question": "Postcode"
+    "address": {
+      "question": "Address"
     },
     "phoneNumber": {
       "question": "Phone number"
     },
     "emailAddress": {
       "question": "Email"
-    }
+    },
+    "change": "Change"
   }
 }

--- a/steps/representative/representative-details/RepresentativeDetails.js
+++ b/steps/representative/representative-details/RepresentativeDetails.js
@@ -4,6 +4,7 @@ const { Question, goTo } = require('@hmcts/one-per-page');
 const { form, text } = require('@hmcts/one-per-page/forms');
 const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
 const { postCode, firstName, lastName, whitelist, phoneNumber } = require('utils/regex');
+const { formatMobileNumber } = require('utils/stringUtils');
 const sections = require('steps/check-your-appeal/sections');
 const Joi = require('joi');
 const paths = require('paths');
@@ -15,6 +16,21 @@ class RepresentativeDetails extends Question {
     static get path() {
 
         return paths.representative.representativeDetails;
+    }
+
+    get CYAOrganisation() {
+
+        return this.fields.organisation.value || userAnswer.NOT_PROVIDED;
+    }
+
+    get CYAPhoneNumber() {
+
+        return this.fields.phoneNumber.value ? formatMobileNumber(this.fields.phoneNumber.value) : userAnswer.NOT_PROVIDED;
+    }
+
+    get CYAEmailAddress() {
+
+        return this.fields.emailAddress.value || userAnswer.NOT_PROVIDED;
     }
 
     get form() {
@@ -87,63 +103,8 @@ class RepresentativeDetails extends Question {
         return [
 
             answer(this, {
-                question: this.content.cya.firstName.question,
                 section: sections.representative,
-                answer: this.fields.firstName.value
-            }),
-
-            answer(this, {
-                question: this.content.cya.lastName.question,
-                section: sections.representative,
-                answer: this.fields.lastName.value
-            }),
-
-            answer(this, {
-                question: this.content.cya.organisation.question,
-                section: sections.representative,
-                answer: this.fields.organisation.value || userAnswer.NOT_PROVIDED
-            }),
-
-            answer(this, {
-                question: this.content.cya.addressLine1.question,
-                section: sections.representative,
-                answer: this.fields.addressLine1.value
-            }),
-
-            answer(this, {
-                question: this.content.cya.addressLine2.question,
-                section: sections.representative,
-                answer: this.fields.addressLine2.value || userAnswer.NOT_PROVIDED
-            }),
-
-            answer(this, {
-                question: this.content.cya.townCity.question,
-                section: sections.representative,
-                answer: this.fields.townCity.value
-            }),
-
-            answer(this, {
-                question: this.content.cya.county.question,
-                section: sections.representative,
-                answer: this.fields.county.value
-            }),
-
-            answer(this, {
-                question: this.content.cya.postCode.question,
-                section: sections.representative,
-                answer: this.fields.postCode.value
-            }),
-
-            answer(this, {
-                question: this.content.cya.phoneNumber.question,
-                section: sections.representative,
-                answer: this.fields.phoneNumber.value || userAnswer.NOT_PROVIDED
-            }),
-
-            answer(this, {
-                question: this.content.cya.emailAddress.question,
-                section: sections.representative,
-                answer: this.fields.emailAddress.value || userAnswer.NOT_PROVIDED
+                template: 'answer.html'
             })
         ];
     }

--- a/steps/representative/representative-details/answer.html
+++ b/steps/representative/representative-details/answer.html
@@ -1,0 +1,31 @@
+<dl class="cya-whatYouDisagreeWith">
+    <dt class="cya-question">{{ content.cya.name.question }}</dt>
+    <dd class="cya-answer">{{ fields.firstName.value }} {{ fields.lastName.value }}</dd>
+    <dd class="cya-change"><a href="{{ path }}">{{ content.cya.change }}</a></dd>
+</dl>
+<dl id="cya-representativedetails-organisation-if-they-work-for-one" class="cya-whatYouDisagreeWith">
+    <dt class="cya-question">{{ content.cya.organisation.question }}</dt>
+    <dd class="cya-answer">{{ CYAOrganisation }}</dd>
+    <dd class="cya-change"></dd>
+</dl>
+<dl class="cya-whatYouDisagreeWith">
+    <dt class="cya-question">{{ content.cya.address.question }}</dt>
+    <dd class="cya-answer">
+        {{ fields.addressLine1.value }}<br>
+        {% if fields.addressLine2.value %}{{ fields.addressLine2.value }}<br>{% endif %}
+        {{ fields.townCity.value }}<br>
+        {{ fields.county.value }}<br>
+        {{ fields.postCode.value }}<br>
+    </dd>
+    <dd class="cya-change"></dd>
+</dl>
+<dl id="cya-representativedetails-email-address" class="cya-whatYouDisagreeWith">
+    <dt class="cya-question">{{ content.cya.emailAddress.question }}</dt>
+    <dd class="cya-answer">{{ CYAEmailAddress }}</dd>
+    <dd class="cya-change"></dd>
+</dl>
+<dl id="cya-representativedetails-phone-number">
+    <dt class="cya-question ">{{ content.cya.phoneNumber.question }}</dt>
+    <dd class="cya-answer">{{ CYAPhoneNumber }}</dd>
+    <dd class="cya-change"></dd>
+</dl>

--- a/steps/representative/representative-details/content.en.json
+++ b/steps/representative/representative-details/content.en.json
@@ -71,35 +71,21 @@
     }
   },
   "cya": {
-    "firstName":{
-      "question": "First name"
-    },
-    "lastName":{
-      "question": "Last name"
+    "name":{
+      "question": "Name"
     },
     "organisation":{
-      "question": "Organisation (if they work for one)"
+      "question": "Organisation"
     },
-    "addressLine1": {
-      "question": "Address line 1"
-    },
-    "addressLine2": {
-      "question": "Address line 2"
-    },
-    "townCity": {
-      "question": "Town/City"
-    },
-    "county": {
-      "question": "County"
-    },
-    "postCode": {
-      "question": "Postcode"
+    "address":{
+      "question": "Address"
     },
     "phoneNumber": {
       "question": "Phone number"
     },
     "emailAddress": {
       "question": "Email address"
-    }
+    },
+    "change": "Change"
   }
 }

--- a/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
+++ b/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const AppellantContactDetails = require('steps/identity/appellant-contact-details/AppellantContactDetails');
 const { expect } = require('test/util/chai');
+const { formatMobileNumber } = require('utils/stringUtils');
+const AppellantContactDetails = require('steps/identity/appellant-contact-details/AppellantContactDetails');
 const paths = require('paths');
 const userAnswer = require('utils/answer');
 
@@ -39,6 +40,32 @@ describe('AppellantContactDetails.js', () => {
 
     });
 
+    describe('get CYAPhoneNumber()', () => {
+
+        it('should return Not Provided if there is no phoneNumber value', () => {
+           expect(appellantContactDetails.CYAPhoneNumber).to.equal(userAnswer.NOT_PROVIDED)
+        });
+
+        it('should return a formatted mobile number if a phoneNumber value has been set', () => {
+            appellantContactDetails.fields.phoneNumber.value = '0800109756';
+            expect(appellantContactDetails.CYAPhoneNumber).to.equal(formatMobileNumber(appellantContactDetails.fields.phoneNumber.value))
+        });
+
+    });
+
+    describe('get CYAEmailAddress()', () => {
+
+        it('should return Not Provided if there is no email value', () => {
+            expect(appellantContactDetails.CYAEmailAddress).to.equal(userAnswer.NOT_PROVIDED)
+        });
+
+        it('should return the email address if an emailaddress value has been set', () => {
+            appellantContactDetails.fields.emailAddress.value = 'myemailaddress@sscs.com';
+            expect(appellantContactDetails.CYAEmailAddress).to.equal(appellantContactDetails.fields.emailAddress.value)
+        });
+
+    });
+
     describe('get form()', () => {
 
         let fields;
@@ -60,25 +87,6 @@ describe('AppellantContactDetails.js', () => {
                     'postCode',
                     'phoneNumber',
                     'emailAddress');
-            });
-
-        });
-
-        describe('optional fields defaulting to \'Not provided\' on CYA', () => {
-
-            it('should display \'Not provided\' when the user omits the addressLine2', () => {
-                const addressLine2 = appellantContactDetails.answers()[1];
-                expect(addressLine2.answer).to.equal(userAnswer.NOT_PROVIDED);
-            });
-
-            it('should display \'Not provided\' when the user omits the phoneNumber', () => {
-                const phoneNumber = appellantContactDetails.answers()[5];
-                expect(phoneNumber.answer).to.equal(userAnswer.NOT_PROVIDED);
-            });
-
-            it('should display \'Not provided\' when the user omits the emailAddress', () => {
-                const emailAddress = appellantContactDetails.answers()[6];
-                expect(emailAddress.answer).to.equal(userAnswer.NOT_PROVIDED);
             });
 
         });
@@ -193,6 +201,24 @@ describe('AppellantContactDetails.js', () => {
                 expect(field.validations).to.not.be.empty;
             });
 
+        });
+
+    });
+
+    describe('answers()', () => {
+
+        let answers;
+
+        before(() => {
+           answers = appellantContactDetails.answers()[0];
+        });
+
+        it('should return expected section', () => {
+            expect(answers.section).to.equal('appellant-details');
+        });
+
+        it('should return expected template', () => {
+            expect(answers.template).to.equal('answer.html');
         });
 
     });

--- a/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
+++ b/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { expect } = require('test/util/chai');
+const { formatMobileNumber } = require('utils/stringUtils');
 const RepresentativeDetails = require('steps/representative/representative-details/RepresentativeDetails');
 const paths = require('paths');
 const userAnswer = require('utils/answer');
@@ -42,6 +43,45 @@ describe('RepresentativeDetails.js', () => {
 
     });
 
+    describe('get CYAOrganisation()', () => {
+
+        it('should return Not Provided if there is no organisation value', () => {
+            expect(representativeDetails.CYAOrganisation).to.equal(userAnswer.NOT_PROVIDED)
+        });
+
+        it('should return the organisation if an organisation value has been set', () => {
+            representativeDetails.fields.organisation.value = 'Organisation';
+            expect(representativeDetails.CYAOrganisation).to.equal(representativeDetails.fields.organisation.value)
+        });
+
+    });
+
+    describe('get CYAPhoneNumber()', () => {
+
+        it('should return Not Provided if there is no phoneNumber value', () => {
+            expect(representativeDetails.CYAPhoneNumber).to.equal(userAnswer.NOT_PROVIDED)
+        });
+
+        it('should return a formatted mobile number if a phoneNumber value has been set', () => {
+            representativeDetails.fields.phoneNumber.value = '0800109756';
+            expect(representativeDetails.CYAPhoneNumber).to.equal(formatMobileNumber(representativeDetails.fields.phoneNumber.value))
+        });
+
+    });
+
+    describe('get CYAEmailAddress()', () => {
+
+        it('should return Not Provided if there is no email value', () => {
+            expect(representativeDetails.CYAEmailAddress).to.equal(userAnswer.NOT_PROVIDED)
+        });
+
+        it('should return the email address if an emailaddress value has been set', () => {
+            representativeDetails.fields.emailAddress.value = 'myemailaddress@sscs.com';
+            expect(representativeDetails.CYAEmailAddress).to.equal(representativeDetails.fields.emailAddress.value)
+        });
+
+    });
+
     describe('get form()', () => {
 
         let fields;
@@ -65,30 +105,6 @@ describe('RepresentativeDetails.js', () => {
                 'emailAddress',
                 'phoneNumber'
             );
-        });
-
-        describe('optional fields defaulting to \'Not provided\' on CYA', () => {
-
-            it('should display \'Not provided\' when the user omits the organisation', () => {
-                const organisation = representativeDetails.answers()[2];
-                expect(organisation.answer).to.equal(userAnswer.NOT_PROVIDED);
-            });
-
-            it('should display \'Not provided\' when the user omits the addressLine2', () => {
-                const addressLine2 = representativeDetails.answers()[4];
-                expect(addressLine2.answer).to.equal(userAnswer.NOT_PROVIDED);
-            });
-
-            it('should display \'Not provided\' when the user omits the phoneNumber', () => {
-                const phoneNumber = representativeDetails.answers()[8];
-                expect(phoneNumber.answer).to.equal(userAnswer.NOT_PROVIDED);
-            });
-
-            it('should display \'Not provided\' when the user omits the emailAddress', () => {
-                const emailAddress = representativeDetails.answers()[9];
-                expect(emailAddress.answer).to.equal(userAnswer.NOT_PROVIDED);
-            });
-
         });
 
         describe('firstName field', () => {
@@ -249,6 +265,24 @@ describe('RepresentativeDetails.js', () => {
                 expect(field.validations).to.not.be.empty;
             });
 
+        });
+
+    });
+
+    describe('answers()', () => {
+
+        let answers;
+
+        before(() => {
+            answers = representativeDetails.answers()[0];
+        });
+
+        it('should return expected section', () => {
+            expect(answers.section).to.equal('representative');
+        });
+
+        it('should return expected template', () => {
+            expect(answers.template).to.equal('answer.html');
         });
 
     });


### PR DESCRIPTION
- Modify Representative Details and Appellant Contact Details in order to display the info in the same section in Check Your Appeal.
- Add `answer.html` to both classes in `answers()`
- Add templates to display the sections in CYA
- Modify Unit tests

<img width="826" alt="screen shot 2018-03-15 at 15 10 54" src="https://user-images.githubusercontent.com/11047071/37472157-4df04142-2863-11e8-8b10-d397ed5d041c.png">

