### PR TITLE
SSCS-2375 CYA Change mobile number

### DIFF
--- a/steps/sms-notify/sms-confirmation/SmsConfirmation.js
+++ b/steps/sms-notify/sms-confirmation/SmsConfirmation.js
@@ -49,7 +49,7 @@ class SmsConfirmation extends Question {
                 question: this.content.cya.mobileNumber.question,
                 section: sections.textMsgReminders,
                 answer: this.mobileNumber,
-                url: paths.smsNotify.sendToNumber
+                url: paths.smsNotify.appellantTextReminders
             })
         ];
     }

--- a/test/unit/steps/sms-notify/sms-confirmation/SmsConfirmation.test.js
+++ b/test/unit/steps/sms-notify/sms-confirmation/SmsConfirmation.test.js
@@ -128,7 +128,7 @@ describe('SmsConfirmation.js', () => {
             expect(answers.length).to.equal(1);
             expect(answers[0].question).to.equal(question);
             expect(answers[0].section).to.equal(sections.textMsgReminders);
-            expect(answers[0].url).to.equal(paths.smsNotify.sendToNumber);
+            expect(answers[0].url).to.equal(paths.smsNotify.appellantTextReminders);
         });
 
         it('should use the same number from the appellant details step', () => {


### PR DESCRIPTION
- Fixes a bug for text reminders when changing mobile number in CYA
```
WHEN a user is on the appellant contact details page
AND THEN leaves phone number field empty
AND continues to text reminders
AND selects yes and enters their mobile number
THEN continues to CYA
THEN clicks change for mobile number
THEN they are shown an error
```
- Changed the url for mobile number CYA so that it goes back to the `appellant-text-reminders- page`.