### PR TITLE
Bug/sscs 2492 rep details conditional validation

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -14,6 +14,12 @@ label.form-label[for="signer"] {
   font-weight: bold;
 }
 
+#nameOrganisation {
+  .form-group:last-child {
+    margin-bottom: 0;
+  }
+}
+
 #item\.whatYouDisagreeWith,
 #item\.reasonForAppealing,
 #otherReasonForAppealing {

--- a/steps/representative/representative-details/RepresentativeDetails.js
+++ b/steps/representative/representative-details/RepresentativeDetails.js
@@ -21,9 +21,16 @@ class RepresentativeDetails extends Question {
         return paths.representative.representativeDetails;
     }
 
+    get CYAName() {
+
+        const firstName = this.fields.nameOrganisation.firstName.value || '';
+        const lastName = this.fields.nameOrganisation.lastName.value || '';
+        return firstName === '' && lastName === '' ? userAnswer.NOT_PROVIDED : `${firstName} ${lastName}`.trim();
+    }
+
     get CYAOrganisation() {
 
-        return this.fields.organisation.value || userAnswer.NOT_PROVIDED;
+        return this.fields.nameOrganisation.organisation.value || userAnswer.NOT_PROVIDED;
     }
 
     get CYAPhoneNumber() {

--- a/steps/representative/representative-details/RepresentativeDetails.js
+++ b/steps/representative/representative-details/RepresentativeDetails.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const { Question, goTo } = require('@hmcts/one-per-page');
-const { form, text } = require('@hmcts/one-per-page/forms');
+const { form, text, object } = require('@hmcts/one-per-page/forms');
 const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
+const { errorFor } = require('@hmcts/one-per-page/src/forms/validator');
 const { postCode, firstName, lastName, whitelist, phoneNumber } = require('utils/regex');
 const { formatMobileNumber } = require('utils/stringUtils');
+const { isNotEmptyString, regexValidation } = require('utils/validationUtils');
 const sections = require('steps/check-your-appeal/sections');
 const Joi = require('joi');
 const paths = require('paths');
@@ -39,27 +41,39 @@ class RepresentativeDetails extends Question {
 
         return form({
 
-            firstName: text
-                .joi(
-                    fields.firstName.error.required,
-                    Joi.string().required()
-                ).joi(
-                    fields.firstName.error.invalid,
-                    Joi.string().trim().regex(firstName)
-                ),
-            lastName: text
-                .joi(
-                    fields.lastName.error.required,
-                    Joi.string().required()
-                ).joi(
-                    fields.lastName.error.invalid,
-                    Joi.string().trim().regex(lastName)
-                ),
-            organisation: text
-                .joi(
-                    fields.organisation.error.invalid,
-                    Joi.string().regex(whitelist).allow('')
-                ),
+            blah: object({
+                firstName: text,
+                lastName: text,
+                organisation: text
+            }).check(
+                errorFor('firstName', fields.firstName.error.required),
+                value => isNotEmptyString(value.firstName)
+            ).check(
+                errorFor('firstName', fields.firstName.error.invalid),
+                value => regexValidation(value.firstName)
+            ),
+
+            // firstName: text
+            //     .joi(
+            //         fields.firstName.error.required,
+            //         Joi.string().required()
+            //     ).joi(
+            //         fields.firstName.error.invalid,
+            //         Joi.string().trim().regex(firstName)
+            //     ),
+            // lastName: text
+            //     .joi(
+            //         fields.lastName.error.required,
+            //         Joi.string().required()
+            //     ).joi(
+            //         fields.lastName.error.invalid,
+            //         Joi.string().trim().regex(lastName)
+            //     ),
+            // organisation: text
+            //     .joi(
+            //         fields.organisation.error.invalid,
+            //         Joi.string().regex(whitelist).allow('')
+            //     ),
             addressLine1: text
                 .joi(
                     fields.addressLine1.error.required,

--- a/steps/representative/representative-details/RepresentativeDetails.js
+++ b/steps/representative/representative-details/RepresentativeDetails.js
@@ -7,6 +7,7 @@ const { errorFor } = require('@hmcts/one-per-page/src/forms/validator');
 const { postCode, firstName, lastName, whitelist, phoneNumber } = require('utils/regex');
 const { formatMobileNumber } = require('utils/stringUtils');
 const { isNotEmptyString, regexValidation } = require('utils/validationUtils');
+const { joiValidation } = require('utils/validationUtils');
 const sections = require('steps/check-your-appeal/sections');
 const Joi = require('joi');
 const paths = require('paths');
@@ -41,39 +42,23 @@ class RepresentativeDetails extends Question {
 
         return form({
 
-            blah: object({
+            nameOrganisation: object({
                 firstName: text,
                 lastName: text,
                 organisation: text
             }).check(
-                errorFor('firstName', fields.firstName.error.required),
-                value => isNotEmptyString(value.firstName)
+                fields.nameOrganisation.error.required,
+                value => Object.keys(value).length > 0
             ).check(
-                errorFor('firstName', fields.firstName.error.invalid),
-                value => regexValidation(value.firstName)
+                errorFor('firstName', fields.nameOrganisation.firstName.error.invalid),
+                value => joiValidation(value.firstName, Joi.string().trim().regex(firstName))
+            ).check(
+                errorFor('lastName', fields.nameOrganisation.lastName.error.invalid),
+                value => joiValidation(value.lastName, Joi.string().trim().regex(lastName))
+            ).check(
+                errorFor('organisation', fields.nameOrganisation.organisation.error.invalid),
+                value => joiValidation(value.organisation,  Joi.string().regex(whitelist))
             ),
-
-            // firstName: text
-            //     .joi(
-            //         fields.firstName.error.required,
-            //         Joi.string().required()
-            //     ).joi(
-            //         fields.firstName.error.invalid,
-            //         Joi.string().trim().regex(firstName)
-            //     ),
-            // lastName: text
-            //     .joi(
-            //         fields.lastName.error.required,
-            //         Joi.string().required()
-            //     ).joi(
-            //         fields.lastName.error.invalid,
-            //         Joi.string().trim().regex(lastName)
-            //     ),
-            // organisation: text
-            //     .joi(
-            //         fields.organisation.error.invalid,
-            //         Joi.string().regex(whitelist).allow('')
-            //     ),
             addressLine1: text
                 .joi(
                     fields.addressLine1.error.required,
@@ -127,9 +112,9 @@ class RepresentativeDetails extends Question {
 
         return {
             representative: {
-                firstName: this.fields.firstName.value,
-                lastName: this.fields.lastName.value,
-                organisation: this.fields.organisation.value,
+                firstName: this.fields.nameOrganisation.firstName.value,
+                lastName: this.fields.nameOrganisation.lastName.value,
+                organisation: this.fields.nameOrganisation.organisation.value,
                 contactDetails: {
                     addressLine1: this.fields.addressLine1.value,
                     addressLine2: this.fields.addressLine2.value,

--- a/steps/representative/representative-details/RepresentativeDetails.js
+++ b/steps/representative/representative-details/RepresentativeDetails.js
@@ -6,7 +6,6 @@ const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
 const { errorFor } = require('@hmcts/one-per-page/src/forms/validator');
 const { postCode, firstName, lastName, whitelist, phoneNumber } = require('utils/regex');
 const { formatMobileNumber } = require('utils/stringUtils');
-const { isNotEmptyString, regexValidation } = require('utils/validationUtils');
 const { joiValidation } = require('utils/validationUtils');
 const sections = require('steps/check-your-appeal/sections');
 const Joi = require('joi');

--- a/steps/representative/representative-details/answer.html
+++ b/steps/representative/representative-details/answer.html
@@ -1,6 +1,6 @@
 <dl class="cya-whatYouDisagreeWith">
     <dt class="cya-question">{{ content.cya.name.question }}</dt>
-    <dd class="cya-answer">{{ fields.firstName.value }} {{ fields.lastName.value }}</dd>
+    <dd class="cya-answer">{{ CYAName }}</dd>
     <dd class="cya-change"><a href="{{ path }}">{{ content.cya.change }}</a></dd>
 </dl>
 <dl id="cya-representativedetails-organisation-if-they-work-for-one" class="cya-whatYouDisagreeWith">

--- a/steps/representative/representative-details/content.en.json
+++ b/steps/representative/representative-details/content.en.json
@@ -4,24 +4,29 @@
   "subtitle": "If you have a professional representative, you can find their contact detais on any letter you've received from them.",
   "noDetails": "I don’t have their details to hand",
   "fields": {
-    "firstName": {
-      "title": "First name",
+    "nameOrganisation": {
       "error": {
-        "required": "Enter your representative's first name",
-        "invalid": "You have entered an invalid first name. Check it and enter it again"
-      }
-    },
-    "lastName": {
-      "title": "Last name(s)",
-      "error": {
-        "required": "Enter your representative's surname",
-        "invalid": "You have entered an invalid surname. Check it and enter it again"
-      }
-    },
-    "organisation": {
-      "title": "Organisation (if they work for one)",
-      "error": {
-        "invalid": "You have entered an invalid name. Check it and enter it again"
+        "required": "Enter your representative's name or the organisation they work for"
+      },
+      "firstName": {
+        "title": "First name",
+        "error": {
+          "required": "Enter your representative's first name",
+          "invalid": "You have entered an invalid first name. Check it and enter it again"
+        }
+      },
+      "lastName": {
+        "title": "Last name(s)",
+        "error": {
+          "required": "Enter your representative's surname",
+          "invalid": "You have entered an invalid surname. Check it and enter it again"
+        }
+      },
+      "organisation": {
+        "title": "Organisation (if they work for one)",
+        "error": {
+          "invalid": "You have entered an invalid name. Check it and enter it again"
+        }
       }
     },
     "addressLine1": {

--- a/steps/representative/representative-details/template.html
+++ b/steps/representative/representative-details/template.html
@@ -1,6 +1,6 @@
 {% extends "components/globals.html" %}
 {% extends "look-and-feel/layouts/question.html" %}
-{% from "look-and-feel/components/fields.njk" import textbox, formSection %}
+{% from "look-and-feel/components/fields.njk" import textbox, formSection, errorClass, errorsFor %}
 
 {% block page_title %}{{ content.titleHead }}{% endblock %}
 
@@ -10,21 +10,24 @@
 
 {% block fields %}
 
-    {% call formSection() %}
-
         <p>{{ content.subtitle}}</p>
 
-        {{ textbox(fields.blah.firstName,    content.fields.firstName.title,     hint="") }}
-        {{ textbox(fields.blah.lastName,     content.fields.lastName.title,      hint="") }}
-        {{ textbox(fields.blah.organisation, content.fields.organisation.title,  hint="") }}
+        <fieldset id="{{ fields.nameOrganisation.id }}" class="form-group {{ errorClass(fields.nameOrganisation) }}">
+
+            {{ errorsFor(fields.nameOrganisation) }}
+
+            {{ textbox(fields.nameOrganisation.firstName,    content.fields.nameOrganisation.firstName.title) }}
+            {{ textbox(fields.nameOrganisation.lastName,     content.fields.nameOrganisation.lastName.title) }}
+            {{ textbox(fields.nameOrganisation.organisation, content.fields.nameOrganisation.organisation.title) }}
+
+        </fieldset>
+
         {{ textbox(fields.addressLine1, content.fields.addressLine1.title,  hint=content.fields.addressLine1.hint) }}
-        {{ textbox(fields.addressLine2, content.fields.addressLine2.title,  hint="") }}
-        {{ textbox(fields.townCity,     content.fields.townCity.title,      hint="") }}
-        {{ textbox(fields.county,       content.fields.county.title,        hint="") }}
-        {{ textbox(fields.postCode,     content.fields.postCode.title,      hint="") }}
+        {{ textbox(fields.addressLine2, content.fields.addressLine2.title) }}
+        {{ textbox(fields.townCity,     content.fields.townCity.title) }}
+        {{ textbox(fields.county,       content.fields.county.title) }}
+        {{ textbox(fields.postCode,     content.fields.postCode.title) }}
         {{ textbox(fields.phoneNumber,  content.fields.phoneNumber.title,   hint=content.fields.phoneNumber.hint) }}
         {{ textbox(fields.emailAddress, content.fields.emailAddress.title,  hint=content.fields.emailAddress.hint) }}
-
-    {% endcall %}
 
 {% endblock %}

--- a/steps/representative/representative-details/template.html
+++ b/steps/representative/representative-details/template.html
@@ -14,9 +14,9 @@
 
         <p>{{ content.subtitle}}</p>
 
-        {{ textbox(fields.firstName,    content.fields.firstName.title,     hint="") }}
-        {{ textbox(fields.lastName,     content.fields.lastName.title,      hint="") }}
-        {{ textbox(fields.organisation, content.fields.organisation.title,  hint="") }}
+        {{ textbox(fields.blah.firstName,    content.fields.firstName.title,     hint="") }}
+        {{ textbox(fields.blah.lastName,     content.fields.lastName.title,      hint="") }}
+        {{ textbox(fields.blah.organisation, content.fields.organisation.title,  hint="") }}
         {{ textbox(fields.addressLine1, content.fields.addressLine1.title,  hint=content.fields.addressLine1.hint) }}
         {{ textbox(fields.addressLine2, content.fields.addressLine2.title,  hint="") }}
         {{ textbox(fields.townCity,     content.fields.townCity.title,      hint="") }}

--- a/test/e2e/page-objects/representative/representativeDetails.js
+++ b/test/e2e/page-objects/representative/representativeDetails.js
@@ -4,8 +4,8 @@ function enterRequiredRepresentativeDetails() {
 
     const I = this;
 
-    I.fillField('#firstName', 'Harry');
-    I.fillField('#lastName', 'Potter');
+    I.fillField('input[name="nameOrganisation.firstName"]', 'Harry');
+    I.fillField('input[name="nameOrganisation.lastName"]', 'Potter');
     I.fillField('#addressLine1', '4 Privet Drive');
     I.fillField('#addressLine2', 'Off Wizards close');
     I.fillField('#county', 'Wizard county');

--- a/test/e2e/page/representative/representativeDetails.test.js
+++ b/test/e2e/page/representative/representativeDetails.test.js
@@ -24,22 +24,44 @@ Scenario('When I fill in the fields and continue, I am taken to the reason for a
 
 Scenario('When I only provide a single character for firstName and lastName I see errors', (I) => {
 
-    I.fillField('#firstName', 'H');
-    I.fillField('#lastName', 'P');
+    I.fillField('input[name="nameOrganisation.firstName"]', 'H');
+    I.fillField('input[name="nameOrganisation.lastName"]', 'P');
     I.click('Continue');
-    I.see(representative.firstName.error.invalid);
-    I.see(representative.lastName.error.invalid);
+    I.see(representative.nameOrganisation.firstName.error.invalid);
+    I.see(representative.nameOrganisation.lastName.error.invalid);
 
 });
 
 Scenario('When I click continue without filling in the fields I see errors', (I) => {
 
     I.click('Continue');
-    I.see(representative.firstName.error.required);
-    I.see(representative.lastName.error.required);
+    I.see(representative.nameOrganisation.error.required);
     I.see(representative.addressLine1.error.required);
     I.see(representative.townCity.error.required);
     I.see(representative.county.error.required);
     I.see(representative.postCode.error.required);
+
+});
+
+Scenario('When I click continue without entering a name or organisation, I see errors', (I) => {
+
+    I.click('Continue');
+    I.see(representative.nameOrganisation.error.required);
+
+});
+
+Scenario('When I enter a name and continue, I don\'t see errors', (I) => {
+
+    I.fillField('input[name="nameOrganisation.firstName"]', 'Harry');
+    I.click('Continue');
+    I.dontSee(representative.nameOrganisation.error.required);
+
+});
+
+Scenario('When I enter an organisation and continue, I don\'t see errors', (I) => {
+
+    I.fillField('input[name="nameOrganisation.organisation"]', 'Hogwarts');
+    I.click('Continue');
+    I.dontSee(representative.nameOrganisation.error.required);
 
 });

--- a/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
+++ b/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
@@ -45,6 +45,35 @@ describe('RepresentativeDetails.js', () => {
 
     });
 
+    describe('get getCYAName()', () => {
+
+        beforeEach(() => {
+            representativeDetails.fields.nameOrganisation.firstName.value = '';
+            representativeDetails.fields.nameOrganisation.lastName.value = '';
+        });
+
+        it('should return Not Provided if firstName or lastName has not been set', () => {
+            expect(representativeDetails.CYAName).to.equal(userAnswer.NOT_PROVIDED);
+        });
+
+        it('should return the firstName if only the firstName has been set', () => {
+            representativeDetails.fields.nameOrganisation.firstName.value = 'FirstName';
+            expect(representativeDetails.CYAName).to.equal('FirstName');
+        });
+
+        it('should return the lastName if only the lastName has been set', () => {
+            representativeDetails.fields.nameOrganisation.lastName.value = 'LastName';
+            expect(representativeDetails.CYAName).to.equal('LastName');
+        });
+
+        it('should return the full name if both firstName and lastName has been set', () => {
+            representativeDetails.fields.nameOrganisation.firstName.value = 'FirstName';
+            representativeDetails.fields.nameOrganisation.lastName.value = 'LastName';
+            expect(representativeDetails.CYAName).to.equal('FirstName LastName');
+        });
+
+    });
+
     describe('get CYAOrganisation()', () => {
 
         it('should return Not Provided if there is no organisation value', () => {
@@ -52,8 +81,8 @@ describe('RepresentativeDetails.js', () => {
         });
 
         it('should return the organisation if an organisation value has been set', () => {
-            representativeDetails.fields.organisation.value = 'Organisation';
-            expect(representativeDetails.CYAOrganisation).to.equal(representativeDetails.fields.organisation.value)
+            representativeDetails.fields.nameOrganisation.organisation.value = 'Organisation';
+            expect(representativeDetails.CYAOrganisation).to.equal(representativeDetails.fields.nameOrganisation.organisation.value)
         });
 
     });
@@ -93,7 +122,7 @@ describe('RepresentativeDetails.js', () => {
             fields = representativeDetails.form.fields;
         });
 
-        it('should contain 10 fields', () => {
+        it('should contain 8 fields', () => {
             expect(Object.keys(fields).length).to.equal(8);
             expect(fields).to.have.all.keys(
                 'nameOrganisation',
@@ -107,39 +136,7 @@ describe('RepresentativeDetails.js', () => {
             );
         });
 
-        describe('firstName field', () => {
-
-            beforeEach(() => {
-                field = fields.firstName;
-            });
-
-            it('has constructor name FieldDescriptor', () => {
-                expect(field.constructor.name).to.eq('FieldDescriptor');
-            });
-
-            it('contains validation', () => {
-                expect(field.validations).to.not.be.empty;
-            });
-
-        });
-
-        describe('lastName field', () => {
-
-            beforeEach(() => {
-                field = fields.lastName;
-            });
-
-            it('has constructor name FieldDescriptor', () => {
-                expect(field.constructor.name).to.eq('FieldDescriptor');
-            });
-
-            it('contains validation', () => {
-                expect(field.validations).to.not.be.empty;
-            });
-
-        });
-
-        describe('organisation field', () => {
+        describe('nameOrganisation field', () => {
 
             beforeEach(() => {
                 field = fields.nameOrganisation;

--- a/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
+++ b/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
@@ -21,9 +21,11 @@ describe('RepresentativeDetails.js', () => {
         });
 
         representativeDetails.fields = {
-            firstName: { value: '' },
-            lastName: { value: '' },
-            organisation: { value: '' },
+            nameOrganisation: {
+                firstName: { value: '' },
+                lastName: { value: '' },
+                organisation: { value: '' }
+            },
             addressLine1: { value: '' },
             addressLine2: { value: '' },
             townCity: { value: '' },
@@ -92,11 +94,9 @@ describe('RepresentativeDetails.js', () => {
         });
 
         it('should contain 10 fields', () => {
-            expect(Object.keys(fields).length).to.equal(10);
+            expect(Object.keys(fields).length).to.equal(8);
             expect(fields).to.have.all.keys(
-                'firstName',
-                'lastName',
-                'organisation',
+                'nameOrganisation',
                 'addressLine1',
                 'addressLine2',
                 'townCity',
@@ -142,7 +142,7 @@ describe('RepresentativeDetails.js', () => {
         describe('organisation field', () => {
 
             beforeEach(() => {
-                field = fields.organisation;
+                field = fields.nameOrganisation;
             });
 
             it('has constructor name FieldDescriptor', () => {
@@ -290,9 +290,9 @@ describe('RepresentativeDetails.js', () => {
     describe('values()', () => {
 
         it('should contain a value object', () => {
-            representativeDetails.fields.firstName.value = 'First name';
-            representativeDetails.fields.lastName.value = 'Last name';
-            representativeDetails.fields.organisation.value = 'Organisation';
+            representativeDetails.fields.nameOrganisation.firstName.value = 'First name';
+            representativeDetails.fields.nameOrganisation.lastName.value = 'Last name';
+            representativeDetails.fields.nameOrganisation.organisation.value = 'Organisation';
             representativeDetails.fields.addressLine1.value = 'First line of my address';
             representativeDetails.fields.addressLine2.value = 'Second line of my address';
             representativeDetails.fields.townCity.value = 'Town or City';

--- a/test/unit/utils/validationUtils.test.js
+++ b/test/unit/utils/validationUtils.test.js
@@ -1,0 +1,28 @@
+const { expect } = require('test/util/chai');
+const { joiValidation } = require('utils/validationUtils');
+const { whitelist } = require('utils/regex');
+const Joi = require('joi');
+
+describe('joiValidation', () => {
+
+    it('should return true if value has been set', () => {
+        const valid = joiValidation('field has a value', Joi.string().required());
+        expect(valid).to.equal(true);
+    });
+
+    it('should return false if value hasn\'t been set', () => {
+        const valid = joiValidation(undefined, Joi.string().required());
+        expect(valid).to.equal(false);
+    });
+
+    it('should return true if value is valid', () => {
+        const valid = joiValidation('valid value!', Joi.string().regex(whitelist));
+        expect(valid).to.equal(true);
+    });
+
+    it('should return false if value isn\'t valid', () => {
+        const valid = joiValidation('<invalid value>', Joi.string().regex(whitelist));
+        expect(valid).to.equal(false);
+    });
+
+});

--- a/utils/validationUtils.js
+++ b/utils/validationUtils.js
@@ -1,0 +1,17 @@
+const Joi = require('joi');
+
+const isNotEmptyString = value => {
+    return value !== undefined || value !== '';
+};
+
+const regexValidation = (value, regex) => {
+
+    const a = Joi.string().trim().regex(value);
+    console.log(a)
+    return false;
+};
+
+module.exports = {
+  isNotEmptyString,
+    regexValidation
+};

--- a/utils/validationUtils.js
+++ b/utils/validationUtils.js
@@ -1,17 +1,8 @@
 const Joi = require('joi');
 
-const isNotEmptyString = value => {
-    return value !== undefined || value !== '';
+const joiValidation = (value, joiSchema) => {
+    const valid = Joi.validate(value, joiSchema);
+    return valid.error === null;
 };
 
-const regexValidation = (value, regex) => {
-
-    const a = Joi.string().trim().regex(value);
-    console.log(a)
-    return false;
-};
-
-module.exports = {
-  isNotEmptyString,
-    regexValidation
-};
+module.exports = { joiValidation };


### PR DESCRIPTION
- Add conditional field validation for rep details `firstName`, `lastName` and `organisation`.
- At least one of those fields must have a value but are not all required.
- For example, these are valid:
        - `firstName: 'Ben', lastName: 'Diggle', Organisation: 'SSCS'`,
        - `firstName: 'Ben', lastName: 'Diggle', Organisation: undefined`,
        - `firstName: 'Ben', lastName: undefined, Organisation: undefined`,
        - `firstName: undefined lastName: 'Diggle', Organisation: undefined`,
        - `firstName: undefined, lastName: undefined, Organisation: 'SSCS'`,

- However, this is not valid:
        - `firstName: undefined, lastName: undefined, Organisation: undefined`

- Added validation util where you can pass the value and the JOI schema which will return true or false. To be used for `object` fields that require `check` validation.
- Added e2e tests.
- Added unit tests
- Adjusted the template to allow the grouping of the three fields.
- Edited the content file
