### PR TITLE
Fix accessibility issues

### DIFF
--- a/steps/compliance/dwp-issuing-office/template.html
+++ b/steps/compliance/dwp-issuing-office/template.html
@@ -12,7 +12,7 @@
 
     <img class="mrn-image issuing-office" src="{{ asset_path }}images/pip-number.png" alt="{{ content.imageAlt }}">
 
-    <p><h3 class="heading-small">{{ content.fields.pipNumber.header }}</h3></p>
+    <p><h2 class="heading-small">{{ content.fields.pipNumber.header }}</h2></p>
 
     {{ textbox(fields.pipNumber, content.fields.pipNumber.label) }}
 

--- a/steps/confirmation/template.html
+++ b/steps/confirmation/template.html
@@ -23,7 +23,7 @@
     <img class="confirmation-image" src="{{ asset_path }}images/progress-bar-appeal-received.svg" alt="{{ content.imageAlt }}">
 
     <div class="description">
-        <h4 class="heading-small">{{ content.next.heading }}</h4>
+        <h2 class="heading-small">{{ content.next.heading }}</h2>
         <p>{{ content.next.notify }}</p>
         <p>{{ content.next.contact }}</p>
     </div>

--- a/steps/reasons-for-appealing/other-reasons-for-appealing/content.en.json
+++ b/steps/reasons-for-appealing/other-reasons-for-appealing/content.en.json
@@ -4,6 +4,7 @@
   "subtitle": "You can tell the tribunal about anything you think may be relevant to your appeal, such as something you feel DWP didn’t consider in their assessment.",
   "fields": {
     "otherReasonForAppealing": {
+      "label": "Other reasons for appealing",
       "error": {
         "invalid": "You've entered a special character. Delete it before continuing"
       }

--- a/steps/reasons-for-appealing/other-reasons-for-appealing/template.html
+++ b/steps/reasons-for-appealing/other-reasons-for-appealing/template.html
@@ -15,7 +15,7 @@
 
 <p>{{ content.subtitle }}</p>
 
-{{ textarea(fields.otherReasonForAppealing, "", hint="") }}
+{{ textarea(fields.otherReasonForAppealing, content.fields.otherReasonForAppealing.label, hideLabel = true) }}
 
 {% endcall %}
 

--- a/steps/sms-notify/send-to-number/content.en.json
+++ b/steps/sms-notify/send-to-number/content.en.json
@@ -3,6 +3,7 @@
   "title": "Shall we send them to the number you provided earlier?",
   "fields": {
     "useSameNumber": {
+      "label": "Select whether to use the same number provided earlier or not",
       "yes": "Yes, send them to {{ phoneNumber }}",
       "no": "No, send them to a different number",
       "error": {

--- a/steps/sms-notify/send-to-number/template.html
+++ b/steps/sms-notify/send-to-number/template.html
@@ -14,8 +14,8 @@
 
         {{ selectionButtons(
             fields.useSameNumber,
-            "",
-            hint = '',
+            content.fields.useSameNumber.label,
+            hideQuestion = true,
             options = [
             { label: content.fields.useSameNumber.yes, value: "yes" },
             { label: content.fields.useSameNumber.no,  value: "no" }


### PR DESCRIPTION
- `Confirmation`: header tags must increment by one. e.g. `h1 -> h2`. Not `h1 -> h3`.
- `DWP-issuing-office`: Same as above.

- `Other-reasons-for-appealing`: Field must have a label. Label added and hidden.
- `Send-to-number`: Same as above.