### PR TITLE
SSCS-3095 Check Your Answers Accessibility links

### DIFF
--- a/steps/hearing/arrangements/answer.html
+++ b/steps/hearing/arrangements/answer.html
@@ -3,7 +3,12 @@
         <dl class="cya-hearingArrangements">
             <dt class="cya-question">{{ content.cya[question] }}</dt>
             <dd class="cya-answer">{{ answer }}</dd>
-            <dd class="cya-change">{% if loop.first %}<a href="{{ path }}">Change</a>{% endif %}</dd>
+            <dd class="cya-change">
+                {% if loop.first %}
+                    <a href="{{ path }}">{{ content.cya.change }}</a>
+                    <span class="visually-hidden"> {{ content.cya.arrangements }}</span>
+                {% endif %}
+            </dd>
         </dl>
     {% endfor %}
 </div>

--- a/steps/hearing/arrangements/content.en.json
+++ b/steps/hearing/arrangements/content.en.json
@@ -62,6 +62,8 @@
     }
   },
   "cya": {
+    "arrangements": "Hearing arrangements",
+    "change": "Change",
     "interpreterLanguage": "Language interpreter",
     "signLanguage": "Sign language interpreter",
     "hearingLoop": "Hearing loop",

--- a/steps/identity/appellant-contact-details/answer.html
+++ b/steps/identity/appellant-contact-details/answer.html
@@ -8,7 +8,10 @@
             {{ fields.county.value }}<br>
             {{ fields.postCode.value }}<br>
         </dd>
-        <dd class="cya-change"><a href="{{ path }}">{{ content.cya.change }}</a></dd>
+        <dd class="cya-change">
+            <a href="{{ path }}">{{ content.cya.change }}</a>
+            <span class="visually-hidden"> {{ content.cya.yourDetails }}</span>
+        </dd>
     </dl>
     <dl id="cya-appellantcontactdetails-email-address" class="cya-whatYouDisagreeWith">
         <dt class="cya-question">{{ content.cya.emailAddress.question }}</dt>

--- a/steps/identity/appellant-contact-details/content.en.json
+++ b/steps/identity/appellant-contact-details/content.en.json
@@ -58,6 +58,7 @@
     "emailAddress": {
       "question": "Email"
     },
-    "change": "Change"
+    "change": "Change",
+    "yourDetails": "Your Contact Details"
   }
 }

--- a/steps/reasons-for-appealing/reason-for-appealing/answer.html
+++ b/steps/reasons-for-appealing/reason-for-appealing/answer.html
@@ -3,7 +3,10 @@
         <dl class="cya-whatYouDisagreeWith">
             <dt class="cya-question">{{ content.cya.reasonForAppealing.questions.whatYouDisagreeWith }}</dt>
             <dd class="cya-answer">{{ item.whatYouDisagreeWith }}</dd>
-            <dd class="cya-change"><a href="{{ path }}">{{ content.cya.reasonForAppealing.changeLink }}</a></dd>
+            <dd class="cya-change">
+                <a href="{{ path }}">{{ content.cya.reasonForAppealing.changeLink }}</a>
+                <span class="visually-hidden"> {{ content.cya.reasonForAppealing.reason }} {{ loop.index }}</span>
+            </dd>
         </dl>
         <dl>
             <dt class="cya-question">{{ content.cya.reasonForAppealing.questions.reasonForAppealing }}</dt>

--- a/steps/reasons-for-appealing/reason-for-appealing/content.en.json
+++ b/steps/reasons-for-appealing/reason-for-appealing/content.en.json
@@ -34,7 +34,8 @@
         "whatYouDisagreeWith": "What you disagree with",
         "reasonForAppealing": "Why you disagree with it"
       },
-      "changeLink": "Change"
+      "changeLink": "Change",
+      "reason": "Reason For Appealing"
     }
   }
 }

--- a/steps/representative/representative-details/answer.html
+++ b/steps/representative/representative-details/answer.html
@@ -2,7 +2,10 @@
     <dl class="cya-whatYouDisagreeWith">
         <dt class="cya-question">{{ content.cya.name.question }}</dt>
         <dd class="cya-answer">{{ CYAName }}</dd>
-        <dd class="cya-change"><a href="{{ path }}">{{ content.cya.change }}</a></dd>
+        <dd class="cya-change">
+            <a href="{{ path }}">{{ content.cya.change }}</a>
+            <span class="visually-hidden"> {{ content.cya.repDetails }}</span>
+        </dd>
     </dl>
     <dl id="cya-representativedetails-organisation-if-they-work-for-one" class="cya-whatYouDisagreeWith">
         <dt class="cya-question">{{ content.cya.organisation.question }}</dt>

--- a/steps/representative/representative-details/content.en.json
+++ b/steps/representative/representative-details/content.en.json
@@ -91,6 +91,7 @@
     "emailAddress": {
       "question": "Email address"
     },
-    "change": "Change"
+    "change": "Change",
+    "repDetails": "Representative Contact Details"
   }
 }


### PR DESCRIPTION
- Add hidden content to change links for custom CYA sections. 
- This is so when users are using screen readers, it reads out what they are changing. E.g. The screen reader will reader out: `Change Hearing arrangements` rather than just `Change`.
- Add the content to it's content file.