### PR TITLE
SSCS-3242 Landing page styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -138,7 +138,10 @@ lookAndFeel.configure(app, {
         return Array.isArray(value);
       },
       timeOut: config.get('redis.timeout'),
-      timeOutMessage: content.timeout.message
+      timeOutMessage: content.timeout.message,
+      relatedContent: content.relatedContent,
+      paths,
+      urls
     }
   },
   development: {

--- a/assets/scss/landing-pages.scss
+++ b/assets/scss/landing-pages.scss
@@ -1,0 +1,128 @@
+.nav-container {
+  padding-bottom: 15px;
+  border-bottom: 1px solid $grey-2;
+
+  .nav-section {
+    font-size: 16px;
+    line-height: 30px;
+    margin-bottom: 20px;
+
+    .nav-list {
+      list-style-type: none;
+      padding-left: 20px;
+
+      li {
+        &:before {
+          content: '— ';
+          margin-left: -25px;
+          padding-right: 5px;
+        }
+      }
+    }
+  }
+}
+
+@media (max-width: 640px) {
+  .nav-list {
+    column-count: 1;
+    padding-left: 0;
+
+    li {
+      margin-left: 1.5em;
+      padding-left: 0.3em;
+    }
+  }
+}
+
+.part-title {
+  @include bold-27;
+  margin-bottom: $gutter-half;
+  margin-top: $gutter-half;
+
+  @include media(tablet) {
+    margin-bottom: $gutter-two-thirds;
+    margin-top: $gutter-two-thirds;
+  }
+}
+
+.pagination {
+  margin: 30px -15px;
+
+  .pagination-list {
+
+    .pagination-item {
+      font-size: 16px;
+      line-height: 1.25;
+      list-style: none;
+      width: 50%;
+
+      &.pagination-next {
+        float: right;
+        text-align: right;
+      }
+
+      &.pagination-prev {
+        float: left;
+        text-align: left;
+      }
+
+      .pagination-link {
+        display: block;
+        padding: 15px;
+        text-decoration: none;
+
+        &:hover {
+          background-color: $grey-4;
+        }
+
+        &:visited {
+          color: #005ea5;
+        }
+
+        .pagination-title {
+          font-size: 27px;
+          line-height: 1.25;
+          display: block;
+        }
+
+        .pagination-icon {
+          margin-bottom: 1px;
+          height: .482em;
+          width: .63em;
+        }
+
+        .pagination-label {
+          display: inline-block;
+          margin-top: 0.1em;
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+}
+
+.govuk-related-items {
+  border-top: 2px solid $govuk-blue;
+  padding-top: 5px;
+
+  .heading-small {
+    margin-bottom: .5em;
+    margin-top: .3em;
+  }
+
+  nav {
+    margin-bottom: 30px;
+
+    .sub-heading {
+      font-size: 16px;
+      line-height: 1.25;
+      border-top: 1px solid #bfc1c3;
+      padding-top: 15px;
+    }
+
+    li {
+      list-style-type: none;
+      margin-top: 10px;
+    }
+  }
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -233,7 +233,6 @@ label.form-label[for="signer"] {
 
     li {
       list-style-type: none;
-      //margin-bottom: 10px;
       margin-top: 10px;
     }
   }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -108,17 +108,6 @@ label.form-label[for="signer"] {
     line-height: 30px;
     margin-bottom: 20px;
 
-    .part-title {
-      @include bold-27;
-      margin-bottom: $gutter-half;
-      margin-top: $gutter-half;
-
-      @include media(tablet) {
-        margin-bottom: $gutter-two-thirds;
-        margin-top: $gutter-two-thirds;
-      }
-    }
-
     .nav-list {
       list-style-type: none;
       padding-left: 20px;
@@ -131,7 +120,54 @@ label.form-label[for="signer"] {
       }
     }
   }
+}
 
+.part-title {
+  @include bold-27;
+  margin-bottom: $gutter-half;
+  margin-top: $gutter-half;
+
+  @include media(tablet) {
+    margin-bottom: $gutter-two-thirds;
+    margin-top: $gutter-two-thirds;
+  }
+}
+
+.pagination {
+  display: block;
+  margin-top: 30px;
+  margin-bottom: 30px;
+  margin-left: -15px;
+  margin-right: -15px;
+
+  .pagination-next {
+    float: right;
+    text-align: right;
+
+    .pagination-link {
+      display: block;
+      padding: 15px;
+      text-decoration: none;
+
+      .pagination-title {
+        font-size: 27px;
+        line-height: 1.25;
+      }
+
+      .pagination-icon {
+        display: inline-block;
+        margin-bottom: 1px;
+        height: .482em;
+        width: .63em;
+      }
+
+      .pagination-label {
+        display: inline-block;
+        margin-top: 0.1em;
+        text-decoration: underline;
+      }
+    }
+  }
 }
 
 .internal-server-error {

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -5,6 +5,7 @@
 @import 'date-picker';
 @import 'h-progress-bar';
 @import 'v-progress-bar';
+@import 'landing-pages';
 
 .form-section {
   margin-bottom: 30px;
@@ -99,143 +100,8 @@ label.form-label[for="signer"] {
   };
 }
 
-.nav-container {
-  padding-bottom: 15px;
-  border-bottom: 1px solid $grey-2;
-
-  .nav-section {
-    font-size: 16px;
-    line-height: 30px;
-    margin-bottom: 20px;
-
-    .nav-list {
-      list-style-type: none;
-      padding-left: 20px;
-      li {
-        &:before {
-          content: '— ';
-          margin-left: -25px;
-          padding-right: 5px;
-        }
-      }
-    }
-  }
-}
-
-.part-title {
-  @include bold-27;
-  margin-bottom: $gutter-half;
-  margin-top: $gutter-half;
-
-  @include media(tablet) {
-    margin-bottom: $gutter-two-thirds;
-    margin-top: $gutter-two-thirds;
-  }
-}
-
-.pagination {
-  display: block;
-  margin-top: 30px;
-  margin-bottom: 30px;
-  margin-left: -15px;
-  margin-right: -15px;
-
-  .pagination-list {
-    margin: 0;
-    padding: 0;
-
-    .pagination-item {
-      font-size: 16px;
-      line-height: 1.25;
-      list-style: none;
-      width: 50%;
-
-      &.pagination-next {
-        float: right;
-        text-align: right;
-      }
-
-      &.pagination-prev {
-        float: left;
-        text-align: left;
-      }
-
-      .pagination-link {
-        display: block;
-        padding: 15px;
-        text-decoration: none;
-
-        &:hover {
-          background-color: $grey-4;
-        }
-
-        &:visited {
-          color: #005ea5;
-        }
-
-        .pagination-title {
-          font-size: 27px;
-          line-height: 1.25;
-          display: block;
-        }
-
-        .pagination-icon {
-          display: inline-block;
-          margin-bottom: 1px;
-          height: .482em;
-          width: .63em;
-        }
-
-        .pagination-label {
-          display: inline-block;
-          margin-top: 0.1em;
-          text-decoration: underline;
-        }
-      }
-    }
-  }
-}
-
 .internal-server-error {
   margin-top: 30px;
-}
-
-@media (max-width: 640px) {
-  .nav-list {
-    column-count: 1;
-    padding-left: 0;
-
-    li {
-      margin-left: 1.5em;
-      padding-left: 0.3em;
-    }
-  }
-}
-
-.govuk-related-items {
-  border-top: 2px solid $govuk-blue;
-  padding-top: 5px;
-
-  .heading-small {
-    margin-bottom: .5em;
-    margin-top: .3em;
-  }
-
-  nav {
-    margin-bottom: 30px;
-
-    .sub-heading {
-      font-size: 16px;
-      line-height: 1.25;
-      border-top: 1px solid #bfc1c3;
-      padding-top: 15px;
-    }
-
-    li {
-      list-style-type: none;
-      margin-top: 10px;
-    }
-  }
 }
 
 .add-another-list {
@@ -296,6 +162,7 @@ label.form-label[for="signer"] {
     }
   }
 }
+
 .screen-reader-text {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
@@ -305,6 +172,7 @@ label.form-label[for="signer"] {
   top: -999px;
   left: -999px;
 }
+
 .progress-bar {
 
   // Display a horizontal progress bar when on larger devices.

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -140,31 +140,57 @@ label.form-label[for="signer"] {
   margin-left: -15px;
   margin-right: -15px;
 
-  .pagination-next {
-    float: right;
-    text-align: right;
+  .pagination-list {
+    margin: 0;
+    padding: 0;
 
-    .pagination-link {
-      display: block;
-      padding: 15px;
-      text-decoration: none;
+    .pagination-item {
+      font-size: 16px;
+      line-height: 1.25;
+      list-style: none;
+      width: 50%;
 
-      .pagination-title {
-        font-size: 27px;
-        line-height: 1.25;
+      &.pagination-next {
+        float: right;
+        text-align: right;
       }
 
-      .pagination-icon {
-        display: inline-block;
-        margin-bottom: 1px;
-        height: .482em;
-        width: .63em;
+      &.pagination-prev {
+        float: left;
+        text-align: left;
       }
 
-      .pagination-label {
-        display: inline-block;
-        margin-top: 0.1em;
-        text-decoration: underline;
+      .pagination-link {
+        display: block;
+        padding: 15px;
+        text-decoration: none;
+
+        &:hover {
+          background-color: $grey-4;
+        }
+
+        &:visited {
+          color: #005ea5;
+        }
+
+        .pagination-title {
+          font-size: 27px;
+          line-height: 1.25;
+          display: block;
+        }
+
+        .pagination-icon {
+          display: inline-block;
+          margin-bottom: 1px;
+          height: .482em;
+          width: .63em;
+        }
+
+        .pagination-label {
+          display: inline-block;
+          margin-top: 0.1em;
+          text-decoration: underline;
+        }
       }
     }
   }
@@ -187,18 +213,29 @@ label.form-label[for="signer"] {
 }
 
 .govuk-related-items {
-  border-top: 10px solid $govuk-blue;
-  margin-top: $gutter;
+  border-top: 2px solid $govuk-blue;
   padding-top: 5px;
 
-  .heading-medium {
+  .heading-small {
     margin-bottom: .5em;
     margin-top: .3em;
   }
 
-  li {
-    list-style-type: none;
-    margin-bottom: 10px;
+  nav {
+    margin-bottom: 30px;
+
+    .sub-heading {
+      font-size: 16px;
+      line-height: 1.25;
+      border-top: 1px solid #bfc1c3;
+      padding-top: 15px;
+    }
+
+    li {
+      list-style-type: none;
+      //margin-bottom: 10px;
+      margin-top: 10px;
+    }
   }
 }
 

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -99,13 +99,39 @@ label.form-label[for="signer"] {
   };
 }
 
-.nav-list {
-  column-count: 2;
-  column-gap: 6em;
-  list-style-type: decimal;
-  padding-left: 20px;
-  font-size: 16px;
-  line-height: 30px;
+.nav-container {
+  padding-bottom: 15px;
+  border-bottom: 1px solid $grey-2;
+
+  .nav-section {
+    font-size: 16px;
+    line-height: 30px;
+    margin-bottom: 20px;
+
+    .part-title {
+      @include bold-27;
+      margin-bottom: $gutter-half;
+      margin-top: $gutter-half;
+
+      @include media(tablet) {
+        margin-bottom: $gutter-two-thirds;
+        margin-top: $gutter-two-thirds;
+      }
+    }
+
+    .nav-list {
+      list-style-type: none;
+      padding-left: 20px;
+      li {
+        &:before {
+          content: '— ';
+          margin-left: -25px;
+          padding-right: 5px;
+        }
+      }
+    }
+  }
+
 }
 
 .internal-server-error {

--- a/content.en.json
+++ b/content.en.json
@@ -20,5 +20,18 @@
   },
   "timeout": {
     "message": "This page will time out in 20 minutes if there is no activity. This is to protect your data."
+  },
+  "relatedContent": {
+    "heading": "Related Content",
+    "benefit": {
+      "calculator": "Benefits calculators",
+      "overPayments": "Benefit overpayments",
+      "fraud": "Benefit fraud"
+    },
+    "explore": {
+      "heading": "Explore the topic",
+      "howItWorks": "How benefits work",
+      "courts": "Courts, sentencing and tribunals"
+    }
   }
 }

--- a/landing-pages/after-you-appeal/content.en.json
+++ b/landing-pages/after-you-appeal/content.en.json
@@ -13,7 +13,7 @@
     "start": "Start an appeal",
     "after": "What happens after you’ve appealed"
   },
-  "heading": "5. What happens after you’ve appealed",
+  "heading": "What happens after you’ve appealed",
   "sentToDepartment": {
     "subHeading": "Your appeal is sent to the department",
     "appealSent": "Your appeal is sent to the department which made the decision about your entitlement to benefits. This will either be the Department for Work and Pensions, HMRC or your local authority."

--- a/landing-pages/after-you-appeal/template.html
+++ b/landing-pages/after-you-appeal/template.html
@@ -1,21 +1,23 @@
 {% extends "landing-page-template.html" %}
+{% from "components/landingPagePagination.html" import pagination %}
 
 {% block page_title %}{{ titleHead }}{% endblock %}
 
 {% block navList -%}
-<div>
+<nav class="nav-section" role="navigation">
+    <h2>Contents</h2>
     <ol class="nav-list">
-        <li><a href="/">{{ navList.overview }}</a></li>
-        <li><a href="/before-you-appeal">{{ navList.before }}</a></li>
-        <li><a href="/help-with-appeal">{{ navList.help }}</a></li>
-        <li><a href="/start-an-appeal">{{ navList.start }}</a></li>
+        <li><a href="{{ paths.landingPages.overview }}">{{ navList.overview }}</a></li>
+        <li><a href="{{ paths.landingPages.beforeYouAppeal }}">{{ navList.before }}</a></li>
+        <li><a href="{{ paths.landingPages.helpWithAppeal }}">{{ navList.help }}</a></li>
+        <li><a href="{{ paths.landingPages.startAnAppeal }}">{{ navList.start }}</a></li>
         <li>{{ navList.after }}</li>
     </ol>
-</div>
+</nav>
 {% endblock %}
 
 {% block infoContent %}
-<h1 class="heading-large">{{ heading }}</h1>
+<h1 class="part-title">{{ heading }}</h1>
 
 <div>
     <h2 class="heading-medium">{{ sentToDepartment.subHeading }}</h2>
@@ -55,4 +57,10 @@
         <p>{{ sendEvidence.sendASAP }}</p>
     </div>
 </div>
+
+{{ pagination(
+    prevLink=paths.landingPages.startAnAppeal,
+    prevLabel=navList.start
+) }}
+
 {%- endblock %}

--- a/landing-pages/before-you-appeal/content.en.json
+++ b/landing-pages/before-you-appeal/content.en.json
@@ -13,7 +13,7 @@
     "start": "Start an appeal",
     "after": "What happens after you’ve appealed"
   },
-  "heading": "2. Before you appeal",
+  "heading": "Before you appeal",
   "reconsideration": "For most benefits you have to ask the Department for Work and Pensions (DWP) to reconsider their decision before you appeal. This is known as requesting ‘mandatory reconsideration’. DWP will then send you a Mandatory Reconsideration Notice (MRN) which tells you whether they have changed their decision. You need your MRN to appeal.",
   "housingBenefit": "If you’re appealing a decision about Housing Benefit then you should <a href='https://www.gov.uk/find-local-council'>contact your local authority</a> before appealing.",
   "childBenefit": "For Child Benefit appeals, <a href='https://www.gov.uk/government/organisations/hm-revenue-customs/contact/child-benefit'>contact HMRC</a> first.",

--- a/landing-pages/before-you-appeal/template.html
+++ b/landing-pages/before-you-appeal/template.html
@@ -1,21 +1,23 @@
 {% extends "landing-page-template.html" %}
+{% from "components/landingPagePagination.html" import pagination %}
 
 {% block page_title %}{{ titleHead }}{% endblock %}
 
 {% block navList -%}
-<div>
+<nav class="nav-section" role="navigation">
+    <h2>Contents</h2>
     <ol class="nav-list">
-        <li><a href="/">{{ navList.overview }}</a></li>
+        <li><a href="{{ paths.landingPages.overview }}">{{ navList.overview }}</a></li>
         <li>{{ navList.before }}</li>
-        <li><a href="/help-with-appeal">{{ navList.help }}</a></li>
-        <li><a href="/start-an-appeal">{{ navList.start }}</a></li>
-        <li><a href="/after-you-appeal">{{ navList.after }}</a></li>
+        <li><a href="{{ paths.landingPages.helpWithAppeal }}">{{ navList.help }}</a></li>
+        <li><a href="{{ paths.landingPages.startAnAppeal }}">{{ navList.start }}</a></li>
+        <li><a href="{{ paths.landingPages.afterYouAppeal }}">{{ navList.after }}</a></li>
     </ol>
-</div>
+</nav>
 {% endblock %}
 
 {% block infoContent %}
-<h1 class="heading-large">{{ heading }}</h1>
+<h1 class="part-title">{{ heading }}</h1>
 
 <p>{{ reconsideration }}</p>
 <p>{{ housingBenefit | safe }}</p>
@@ -25,4 +27,12 @@
 <div class="panel panel-border-wide">
     <p>{{ upToAMonth }}</p>
 </div>
+
+{{ pagination(
+    prevLink=paths.landingPages.overview,
+    prevLabel=navList.overview,
+    nextLink=paths.landingPages.helpWithAppeal,
+    nextLabel=navList.help
+) }}
+
 {%- endblock %}

--- a/landing-pages/help-with-appeal/content.en.json
+++ b/landing-pages/help-with-appeal/content.en.json
@@ -13,7 +13,7 @@
     "start": "Start an appeal",
     "after": "What happens after you’ve appealed"
   },
-  "heading": "3. Help with your appeal",
+  "heading": "Help with your appeal",
   "support": "There’s various support available before and during your appeal.",
   "representative": {
     "subHeading": "Representatives",

--- a/landing-pages/help-with-appeal/template.html
+++ b/landing-pages/help-with-appeal/template.html
@@ -1,21 +1,23 @@
 {% extends "landing-page-template.html" %}
+{% from "components/landingPagePagination.html" import pagination %}
 
 {% block page_title %}{{ titleHead }}{% endblock %}
 
 {% block navList -%}
-<div>
+<nav class="nav-section" role="navigation">
+    <h2>Contents</h2>
     <ol class="nav-list">
-        <li><a href="/">{{ navList.overview }}</a></li>
-        <li><a href="/before-you-appeal">{{ navList.before }}</a></li>
+        <li><a href="{{ paths.landingPages.overview }}">{{ navList.overview }}</a></li>
+        <li><a href="{{ paths.landingPages.beforeYouAppeal }}">{{ navList.before }}</a></li>
         <li>{{ navList.help }}</li>
-        <li><a href="/start-an-appeal">{{ navList.start }}</a></li>
-        <li><a href="/after-you-appeal">{{ navList.after }}</a></li>
+        <li><a href="{{ paths.landingPages.startAnAppeal }}">{{ navList.start }}</a></li>
+        <li><a href="{{ paths.landingPages.afterYouAppeal }}">{{ navList.after }}</a></li>
     </ol>
-</div>
+</nav>
 {% endblock %}
 
 {% block infoContent %}
-<h1 class="heading-large">{{ heading }}</h1>
+<h1 class="part-title">{{ heading }}</h1>
 <p>{{ support }}</p>
 
 <div>
@@ -55,5 +57,12 @@
     <h2 class="heading-medium">{{ financialSupport.subHeading }}</h2>
     <p>{{ financialSupport.contact | safe }}</p>
 </div>
+
+{{ pagination(
+    prevLink=paths.landingPages.beforeYouAppeal,
+    prevLabel=navList.before,
+    nextLink=paths.landingPages.startAnAppeal,
+    nextLabel=navList.start
+) }}
 
 {%- endblock %}

--- a/landing-pages/landing-page-template.html
+++ b/landing-pages/landing-page-template.html
@@ -19,8 +19,10 @@
 {% block two_thirds -%}
 
     {{ header(title, size='xlarge') }}
-    {% block navList -%}{%- endblock %}
-    <hr>
+    <aside class="nav-container" role="complementary">
+        {% block navList -%}{%- endblock %}
+    </aside>
+
     {% block infoContent -%}{%- endblock %}
 
 {%- endblock %}

--- a/landing-pages/landing-page-template.html
+++ b/landing-pages/landing-page-template.html
@@ -16,14 +16,43 @@
     </div>
 {% endblock %}
 
-{% block two_thirds -%}
 
-    {{ header(title, size='xlarge') }}
 
-    <aside class="nav-container" role="complementary">
-        {% block navList -%}{%- endblock %}
-    </aside>
+{% block full_width -%}
 
-    {% block infoContent -%}{%- endblock %}
+    <div class="grid-row">
+
+        <div class="column-two-thirds">
+            {{ header(title, size='xlarge') }}
+            <aside class="nav-container" role="complementary">
+                {% block navList -%}{%- endblock %}
+            </aside>
+        </div>
+
+        <div class="column-two-thirds">
+            {% block infoContent -%}{%- endblock %}
+        </div>
+
+        <div class="column-one-third">
+            <aside class="govuk-related-items">
+                <h2 class="heading-small">{{ relatedContent.heading }}</h2>
+                <nav role="navigation">
+                    <ul class="font-xsmall">
+                        <li><a href="{{ urls.relatedContent.benefit.calculator }}">{{ relatedContent.benefit.calculator }}</a></li>
+                        <li><a href="{{ urls.relatedContent.benefit.overPayments }}">{{ relatedContent.benefit.overPayments }}</a></li>
+                        <li><a href="{{ urls.relatedContent.benefit.fraud }}">{{ relatedContent.benefit.fraud }}</a></li>
+                    </ul>
+                </nav>
+                <nav>
+                    <h3 class="sub-heading">{{ relatedContent.explore.heading }}</h3>
+                    <ul class="font-xsmall">
+                        <li class="bold"><a href="{{ urls.relatedContent.explore.howItWorks }}">{{ relatedContent.explore.howItWorks }}</a></li>
+                        <li class="bold"><a href="{{ urls.relatedContent.explore.courts }}">{{ relatedContent.explore.courts }}</a></li>
+                    </ul>
+                </nav>
+            </aside>
+        </div>
+
+    </div>
 
 {%- endblock %}

--- a/landing-pages/landing-page-template.html
+++ b/landing-pages/landing-page-template.html
@@ -19,6 +19,7 @@
 {% block two_thirds -%}
 
     {{ header(title, size='xlarge') }}
+
     <aside class="nav-container" role="complementary">
         {% block navList -%}{%- endblock %}
     </aside>

--- a/landing-pages/overview/content.en.json
+++ b/landing-pages/overview/content.en.json
@@ -13,7 +13,7 @@
     "start": "Start an appeal",
     "after": "What happens after you’ve appealed"
   },
-  "heading": "1. Overview",
+  "heading": "Overview",
   "youCanAppeal": "You can appeal if you disagree with a decision that was made about your entitlement to benefits. For example Personal Independence Payment (PIP), Employment and Support Allowance (ESA) or Universal Credit (UC).",
   "decision": "Your appeal will be decided by an independent panel of people known as a tribunal. There will always be a judge on the tribunal panel and sometimes a doctor or disabiilty expert, depending on the benefit you are appealing. They will make an impartial decision on your entitlement to benefits.",
   "subheading": "Benefit decisions you can appeal",

--- a/landing-pages/overview/template.html
+++ b/landing-pages/overview/template.html
@@ -1,4 +1,5 @@
 {% extends "landing-page-template.html" %}
+{% from "components/landingPagePagination.html" import pagination %}
 
 {% block page_title %}{{ titleHead }}{% endblock %}
 
@@ -7,10 +8,10 @@
     <h2>Contents</h2>
     <ol class="nav-list">
         <li>{{ navList.overview }}</li>
-        <li><a href="/before-you-appeal">{{ navList.before }}</a></li>
-        <li><a href="/help-with-appeal">{{ navList.help }}</a></li>
-        <li><a href="/start-an-appeal">{{ navList.start }}</a></li>
-        <li><a href="/after-you-appeal">{{ navList.after }}</a></li>
+        <li><a href="{{ paths.landingPages.beforeYouAppeal }}">{{ navList.before }}</a></li>
+        <li><a href="{{ paths.landingPages.helpWithAppeal }}">{{ navList.help }}</a></li>
+        <li><a href="{{ paths.landingPages.startAnAppeal }}">{{ navList.start }}</a></li>
+        <li><a href="{{ paths.landingPages.afterYouAppeal }}">{{ navList.after }}</a></li>
     </ol>
 </nav>
 {% endblock %}
@@ -48,19 +49,6 @@
     <p>{{ upToAMonth }}</p>
 </div>
 
-<nav class="pagination" role="navigation" aria-label="Pagination">
-    <ul>
-        <li class="pagination-next">
-            <a class="pagination-link" href="/meow">
-                <span class="pagination-title">
-                    Next
-                <img class="pagination-icon"/>
-                </span>
-                <span class="visually-hidden">:</span>
-                <span class="pagination-label">Before you appeal</span>
-            </a>
-        </li>
-    </ul>
-</nav>
+{{ pagination(nextLink=paths.landingPages.beforeYouAppeal, nextLabel=navList.before) }}
 
 {%- endblock %}

--- a/landing-pages/overview/template.html
+++ b/landing-pages/overview/template.html
@@ -48,4 +48,19 @@
     <p>{{ upToAMonth }}</p>
 </div>
 
+<nav class="pagination" role="navigation" aria-label="Pagination">
+    <ul>
+        <li class="pagination-next">
+            <a class="pagination-link" href="/meow">
+                <span class="pagination-title">
+                    Next
+                <img class="pagination-icon"/>
+                </span>
+                <span class="visually-hidden">:</span>
+                <span class="pagination-label">Before you appeal</span>
+            </a>
+        </li>
+    </ul>
+</nav>
+
 {%- endblock %}

--- a/landing-pages/overview/template.html
+++ b/landing-pages/overview/template.html
@@ -3,7 +3,8 @@
 {% block page_title %}{{ titleHead }}{% endblock %}
 
 {% block navList -%}
-<div>
+<nav class="nav-section" role="navigation">
+    <h2>Contents</h2>
     <ol class="nav-list">
         <li>{{ navList.overview }}</li>
         <li><a href="/before-you-appeal">{{ navList.before }}</a></li>
@@ -11,11 +12,11 @@
         <li><a href="/start-an-appeal">{{ navList.start }}</a></li>
         <li><a href="/after-you-appeal">{{ navList.after }}</a></li>
     </ol>
-</div>
+</nav>
 {% endblock %}
 
 {% block infoContent %}
-<h1 class="heading-large">{{ heading }}</h1>
+<h1 class="part-title">{{ heading }}</h1>
 <p>{{ youCanAppeal }}</p>
 <p>{{ decision }}</p>
 

--- a/landing-pages/start-an-appeal/content.en.json
+++ b/landing-pages/start-an-appeal/content.en.json
@@ -13,7 +13,7 @@
     "start": "Start an appeal",
     "after": "What happens after you’ve appealed"
   },
-  "heading": "4. Start an appeal",
+  "heading": "Start an appeal",
   "example": "Use this service to appeal a benefit decision that you don’t agree with. For example, Personal Independence Payment (PIP), Employment and Support Allowance (ESA) or Universal Credit (UC).",
   "whatYouNeed": "To appeal you’ll need:",
   "whatYouNeedList": {

--- a/landing-pages/start-an-appeal/template.html
+++ b/landing-pages/start-an-appeal/template.html
@@ -1,21 +1,23 @@
 {% extends "landing-page-template.html" %}
+{% from "components/landingPagePagination.html" import pagination %}
 
 {% block page_title %}{{ titleHead }}{% endblock %}
 
 {% block navList -%}
-    <div>
-        <ol class="nav-list">
-            <li><a href="/">{{ navList.overview }}</a></li>
-            <li><a href="/before-you-appeal">{{ navList.before }}</a></li>
-            <li><a href="/help-with-appeal">{{ navList.help }}</a></li>
-            <li>{{ navList.start }}</li>
-            <li><a href="/after-you-appeal">{{ navList.after }}</a></li>
-        </ol>
-    </div>
+<nav class="nav-section" role="navigation">
+    <h2>Contents</h2>
+    <ol class="nav-list">
+        <li><a href="{{ paths.landingPages.overview }}">{{ navList.overview }}</a></li>
+        <li><a href="{{ paths.landingPages.beforeYouAppeal }}">{{ navList.before }}</a></li>
+        <li><a href="{{ paths.landingPages.helpWithAppeal }}">{{ navList.help }}</a></li>
+        <li>{{ navList.start }}</li>
+        <li><a href="{{ paths.landingPages.afterYouAppeal }}">{{ navList.after }}</a></li>
+    </ol>
+</nav>
 {% endblock %}
 
 {% block infoContent %}
-<h1 class="heading-large">{{ heading }}</h1>
+<h1 class="part-title">{{ heading }}</h1>
 <p>{{ example }}</p>
 <p>{{ whatYouNeed }}</p>
 <ul class="list list-bullet">
@@ -25,4 +27,12 @@
 </ul>
 
 <a class="button button-start" href="/entry">{{ start }}</a>
+
+{{ pagination(
+    prevLink=paths.landingPages.helpWithAppeal,
+    prevLabel=navList.help,
+    nextLink=paths.landingPages.afterYouAppeal,
+    nextLabel=navList.after
+) }}
+
 {%- endblock %}

--- a/test/e2e/codecept.conf.js
+++ b/test/e2e/codecept.conf.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-process-env */
 const config = require('config');
 
 exports.config = {
@@ -6,7 +7,7 @@ exports.config = {
   timeout: 1000,
   helpers: {
     Nightmare: {
-      url: config.get('e2e.frontendUrl'),
+      url: process.env.TEST_URL || config.get('e2e.frontendUrl'),
       waitForTimeout: parseInt(config.get('e2e.waitForTimeout')),
       waitForAction: parseInt(config.get('e2e.waitForAction')),
       show: false,

--- a/urls.js
+++ b/urls.js
@@ -4,5 +4,16 @@ module.exports = {
   formDownload: {
     sscs1: 'http://formfinder.hmctsformfinder.justice.gov.uk/sscs1-eng.pdf',
     sscs5: 'http://formfinder.hmctsformfinder.justice.gov.uk/sscs5-eng.pdf'
+  },
+  relatedContent: {
+    benefit: {
+      calculator: 'https://www.gov.uk/benefits-calculators',
+      overPayments: 'https://www.gov.uk/benefit-overpayments',
+      fraud: 'https://www.gov.uk/benefit-fraud'
+    },
+    explore: {
+      howItWorks: 'https://www.gov.uk/browse/benefits/entitlement',
+      courts: 'https://www.gov.uk/browse/justice/courts-sentencing-tribunals'
+    }
   }
 };

--- a/views/components/landingPagePagination.html
+++ b/views/components/landingPagePagination.html
@@ -5,7 +5,7 @@
                 <li class="pagination-item pagination-prev">
                     <a class="pagination-link" href="{{ prevLink }}">
                         <span class="pagination-title">
-                            <svg class="pagination-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+                            <svg class="pagination-icon">
                                 <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
                             </svg>
                             Previous
@@ -20,7 +20,7 @@
                     <a class="pagination-link" href="{{ nextLink }}">
                         <span class="pagination-title">
                             Next
-                            <svg class="pagination-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+                            <svg class="pagination-icon">
                                 <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
                             </svg>
                         </span>

--- a/views/components/landingPagePagination.html
+++ b/views/components/landingPagePagination.html
@@ -1,0 +1,34 @@
+{% macro pagination(prevLink="", prevLabel="", nextLink="", nextLabel="") %}
+    <nav class="pagination" role="navigation" aria-label="Pagination">
+        <ul class="pagination-list">
+            {% if prevLink %}
+                <li class="pagination-item pagination-prev">
+                    <a class="pagination-link" href="{{ prevLink }}">
+                        <span class="pagination-title">
+                            <svg class="pagination-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+                                <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+                            </svg>
+                            Previous
+                        </span>
+                        <span class="visually-hidden">:</span>
+                        <span class="pagination-label">{{ prevLabel }}</span>
+                    </a>
+                </li>
+            {% endif %}
+            {% if nextLink %}
+                <li class="pagination-item pagination-next">
+                    <a class="pagination-link" href="{{ nextLink }}">
+                        <span class="pagination-title">
+                            Next
+                            <svg class="pagination-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+                                <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+                            </svg>
+                        </span>
+                        <span class="visually-hidden">:</span>
+                        <span class="pagination-label">{{ nextLabel }}</span>
+                    </a>
+                </li>
+            {% endif %}
+        </ul>
+    </nav>
+{% endmacro %}


### PR DESCRIPTION
- Modify list of contents at begging of page to one column and dashes instead of numbered bullet points.
- Change headings to medium size and remove number from them.
- Add pagination to the bottom of the page.
- Add related contents side column.

- In app.js added relatedContent, urls and paths to nunjucks globals.
- Creating a landing-page SASS file as it is quite big. Imported in the main.scss.
- Added the related content to the globals content file.
- Created a pagination macro to be reused