### PR TITLE
SSCS-3266 Evidence reminder

### DIFF
--- a/steps/reasons-for-appealing/other-reasons-for-appealing/OtherReasonForAppealing.js
+++ b/steps/reasons-for-appealing/other-reasons-for-appealing/OtherReasonForAppealing.js
@@ -40,6 +40,7 @@ class OtherReasonForAppealing extends Question {
   }
 
   next() {
+    // console.log(this.journey);
     return goTo(this.journey.steps.SendingEvidence);
   }
 }

--- a/steps/reasons-for-appealing/other-reasons-for-appealing/OtherReasonForAppealing.js
+++ b/steps/reasons-for-appealing/other-reasons-for-appealing/OtherReasonForAppealing.js
@@ -40,7 +40,6 @@ class OtherReasonForAppealing extends Question {
   }
 
   next() {
-    // console.log(this.journey);
     return goTo(this.journey.steps.SendingEvidence);
   }
 }

--- a/steps/reasons-for-appealing/sending-evidence/SendingEvidence.js
+++ b/steps/reasons-for-appealing/sending-evidence/SendingEvidence.js
@@ -1,33 +1,31 @@
-const { Question, goTo } = require('@hmcts/one-per-page');
-const { form, text } = require('@hmcts/one-per-page/forms');
-const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
+const { goTo } = require('@hmcts/one-per-page');
+const { form, text, ref } = require('@hmcts/one-per-page/forms');
+const { Interstitial } = require('@hmcts/one-per-page/steps');
 const paths = require('paths');
 
 const config = require('config');
 
 const evidenceUploadEnabled = config.get('features.evidenceUpload.enabled');
 
-class SendingEvidence extends Question {
+class SendingEvidence extends Interstitial {
   static get path() {
     return paths.reasonsForAppealing.sendingEvidence;
   }
 
   get hasSignedUpForEmail() {
-    if (typeof this.fields.emailAddress.value === 'undefined') {
+    const appellantEmailField = form({
+      emailAddress: ref(this.journey.steps.AppellantContactDetails, text, 'emailAddress')
+    });
+    const emailFieldValue = appellantEmailField
+      .retrieve(this.journey.steps.AppellantContactDetails, this.req)
+      .emailAddress
+      .value;
+
+    if (typeof emailFieldValue === 'undefined') {
       return false;
     }
 
-    return this.fields.emailAddress.value.length > 0;
-  }
-
-  get form() {
-    return form({
-      emailAddress: text.ref(this.journey.steps.AppellantContactDetails, 'emailAddress')
-    });
-  }
-
-  answers() {
-    return answer(this, { hide: true });
+    return emailFieldValue.length > 0;
   }
 
   next() {

--- a/steps/reasons-for-appealing/sending-evidence/content.en.json
+++ b/steps/reasons-for-appealing/sending-evidence/content.en.json
@@ -4,7 +4,6 @@
   "healthcarePro": "Evidence includes anything which shows how your condition affects your life, such as a letter from your doctor or healthcare professional.",
   "writeStatement": "You or someone who knows you could also write a statement. It all helps the independent tribunal understand your appeal.",
   "sendEvidence": "Send in any evidence as soon as possible after you’ve submitted your appeal. This is so there’s time to read it before your hearing.",
-  "notAlreadySent": "Only send evidence which you have not already sent to DWP.",
   "postEvidence": "You’ll get a letter telling you the address to post your evidence a few days after submitting your appeal.",
   "postEvidenceWithEmail": "You’ll get a letter and an email telling you the address to post your evidence a few days after submitting your appeal."
 }

--- a/steps/reasons-for-appealing/sending-evidence/content.en.json
+++ b/steps/reasons-for-appealing/sending-evidence/content.en.json
@@ -2,8 +2,9 @@
   "titleHead": "Sending evidence - Appeal a benefit decision - GOV.UK",
   "title": "Sending evidence to support your appeal",
   "healthcarePro": "Evidence includes anything which shows how your condition affects your life, such as a letter from your doctor or healthcare professional.",
-  "writeStatement": "Someone who knows you could also write a statement. It all helps the independent tribunal understand your appeal.",
+  "writeStatement": "You or someone who knows you could also write a statement. It all helps the independent tribunal understand your appeal.",
   "sendEvidence": "Send in any evidence as soon as possible after you’ve submitted your appeal. This is so there’s time to read it before your hearing.",
+  "notAlreadySent": "Only send evidence which you have not already sent to DWP.",
   "postEvidence": "You’ll get a letter telling you the address to post your evidence a few days after submitting your appeal.",
   "postEvidenceWithEmail": "You’ll get a letter and an email telling you the address to post your evidence a few days after submitting your appeal."
 }

--- a/steps/reasons-for-appealing/sending-evidence/template.html
+++ b/steps/reasons-for-appealing/sending-evidence/template.html
@@ -13,10 +13,6 @@
 <p>{{ content.writeStatement }}</p>
 <p>{{ content.sendEvidence }}</p>
 
-<div class="panel panel-border-wide">
-    <p>{{ content.notAlreadySent }}</p>
-</div>
-
 <p>
     {% if hasSignedUpForEmail %}
         {{ content.postEvidenceWithEmail }}

--- a/steps/reasons-for-appealing/sending-evidence/template.html
+++ b/steps/reasons-for-appealing/sending-evidence/template.html
@@ -13,11 +13,17 @@
 <p>{{ content.writeStatement }}</p>
 <p>{{ content.sendEvidence }}</p>
 
-{% if hasSignedUpForEmail %}
-    {{ content.postEvidenceWithEmail }}
-{% else %}
-    {{ content.postEvidence }}
-{% endif %}
+<div class="panel panel-border-wide">
+    <p>{{ content.notAlreadySent }}</p>
+</div>
+
+<p>
+    {% if hasSignedUpForEmail %}
+        {{ content.postEvidenceWithEmail }}
+    {% else %}
+        {{ content.postEvidence }}
+    {% endif %}
+</p>
 
 {% call formSection() %}
 {% endcall %}


### PR DESCRIPTION
- Fixed a bug where one-per-page would skip the Evidence Reminder page. This is because previously it was using the `form` method extended from the `Question` class. This was so we could get a value from another step. However, one-per-page has some logic where it says: if the page has been validated and is valid then move on the next step (I believe this is to do with changing your answer in the check your answers page). As there is no actual field on this page and is just content, it was always valid and so was skipped.

In `SendingEvidence.js`
- Changed the class to extend from `Interstitial` class not `Question`.
- Removed `form` and `answer` method from class as it is not a part of Interstitial class.
- Modified `hasSignedUpForEmail` getter to get the value of the field from the other step.

Also:
- Modified the content and html of the page.
- Modified the unit tests to reflect the class change using proxyquire to mock getting the value of the field from another step.

