### PR TITLE
Rejigged slightly the code and added unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "http-status-codes": "^1.3.0",
     "moment": "^2.18.1",
     "nsp": "^3.1.0",
-    "proxyquire": "^2.0.1",
     "request": "^2.87.0",
     "superagent": "^3.8.2"
   },
@@ -63,6 +62,7 @@
     "nyc": "^11.4.0",
     "portscanner": "^2.1.1",
     "pre-commit": "^1.2.2",
+    "proxyquire": "^2.0.1",
     "sinon": "^5.0.7",
     "sinon-chai": "^3.0.0",
     "sonar-scanner": "^3.0.3",

--- a/steps/reasons-for-appealing/evidence-upload/EvidenceUpload.js
+++ b/steps/reasons-for-appealing/evidence-upload/EvidenceUpload.js
@@ -28,12 +28,11 @@ class EvidenceUpload extends Question {
   static handleUpload(req, res, next) {
     const pathToUploadFolder = './../../../uploads';
     const logger = Logger.getLogger('EvidenceUpload.js');
-
-    EvidenceUpload.makeDir(pathToUploadFolder, mkdirError => {
-      if (mkdirError) {
-        return next(mkdirError);
-      }
-      if (req.method.toLowerCase() === 'post') {
+    if (req.method.toLowerCase() === 'post') {
+      return EvidenceUpload.makeDir(pathToUploadFolder, mkdirError => {
+        if (mkdirError) {
+          return next(mkdirError);
+        }
         const incoming = new formidable.IncomingForm({
           uploadDir: pt.resolve(__dirname, pathToUploadFolder),
           keepExtensions: true,
@@ -87,9 +86,9 @@ class EvidenceUpload extends Question {
             return next(forwardingError);
           });
         });
-      }
-      return next();
-    });
+      });
+    }
+    return next();
   }
 
   get middleware() {

--- a/test/unit/middleware/EvidenceUpload.test.js
+++ b/test/unit/middleware/EvidenceUpload.test.js
@@ -1,0 +1,137 @@
+const { expect } = require('test/util/chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+describe('The EvidenceUpload middleware', () => {
+
+  const stubs = {
+    fs: {
+      stat: sinon.stub().yields(null, {
+        isDirectory: () => true
+      }),
+      mkdir: sinon.stub().callsArg(1)
+    }
+  };
+  let EvidenceUpload = proxyquire('steps/reasons-for-appealing/evidence-upload/EvidenceUpload.js', stubs);
+
+  describe('static makedir', () => {
+
+    beforeEach(() => {
+      stubs.fs.mkdir.reset();
+    });
+
+    it('doesn\'t create the folder uploads if there is one', () => {
+      stubs.fs.stat = sinon.stub().yields(null, {
+        isDirectory: () => true
+      });
+      return EvidenceUpload.makeDir('/uploads', () => {
+        return expect(stubs.fs.mkdir).to.not.have.been.called;
+      })
+    });
+  });
+
+  describe('static handleUpload', () => {
+
+    let EvidenceUpload;
+    let stubs;
+    let parser = sinon.stub().yields(null, [], {
+      uploadEv: {
+        name: 'giacomo'
+      }
+    });
+    let unlinker = sinon.stub().yields();
+    let poster = sinon.stub().yields(null, null, `{
+      "documents": [{
+        "originalDocumentName": "ugo",
+        "_links": {
+          "self": {
+            "href": "www.bigcheese.com"
+          }
+        }
+      }]}`);
+
+    beforeEach(function () {
+      this.timeout(2500);
+      stubs = {
+        formidable: {
+          IncomingForm: function () {
+            this.parse = parser;
+            this.once = () => {};
+            this.on = () => {};
+          }
+        },
+        request: {
+          post: poster
+        },
+        fs: {
+          unlink: unlinker,
+          createReadStream: () => {}
+        },
+        path: {
+          resolve: () => 'a string'
+        }
+      };
+      EvidenceUpload = proxyquire('steps/reasons-for-appealing/evidence-upload/EvidenceUpload.js', stubs);
+      EvidenceUpload.makeDir = sinon.stub().callsArg(1);
+    });
+
+    afterEach(() => {
+      parser.reset();
+      unlinker.reset();
+      poster.reset();
+    });
+    it('creates a directory, forwards the file to the api then deletes it', done => {
+      EvidenceUpload.handleUpload({
+        method: 'post'
+      }, {}, error => {
+        expect (EvidenceUpload.makeDir).to.have.been.called;
+        expect (parser).to.have.been.called;
+        expect (poster).to.have.been.called;
+        expect (unlinker).to.have.been.called;
+        expect(error).not.to.exist;
+        done();
+      });
+    });
+    it('if create directory fails, it invokes the callback with the error', done => {
+      EvidenceUpload.makeDir = sinon.stub().yields(new Error('Bad dir!'));
+      EvidenceUpload.handleUpload({
+        method: 'post'
+      }, {}, error => {
+        expect (EvidenceUpload.makeDir).to.have.been.called;
+        expect (parser).not.to.have.been.called;
+        expect (poster).not.to.have.been.called;
+        expect (unlinker).not.to.have.been.called;
+        expect(error).to.exist;
+        done();
+      });
+    });
+    it('if uploading fails, it invokes the callback with the error', done => {
+      parser = sinon.stub().yields(new Error('argh!'), [], {
+        uploadEv: {
+          name: 'giacomo'
+        }
+      });
+      EvidenceUpload.handleUpload({
+        method: 'post'
+      }, {}, error => {
+        expect (EvidenceUpload.makeDir).to.have.been.called;
+        expect (parser).to.have.been.called;
+        expect (poster).not.to.have.been.called;
+        expect (unlinker).not.to.have.been.called;
+        expect(error).to.exist;
+        done();
+      });
+    });
+    it('if req.method is not post, it doesn\'t do anything apart from just invoking the callback', done => {
+      EvidenceUpload.handleUpload({
+        method: 'get'
+      }, {}, error => {
+        expect (EvidenceUpload.makeDir).not.to.have.been.called;
+        expect (parser).not.to.have.been.called;
+        expect (poster).not.to.have.been.called;
+        expect(error).not.to.exist;
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Since the pr for the evidence upload was already approved, I am opening a pr on a pr. 

I've changed slightly the order of the operations to avoid calling `mkdir` more than necessary, and I have added unit tests for the middleware.