### PR TITLE
SSCS-3417 ITHC Make cookie secure

### DIFF
--- a/app.js
+++ b/app.js
@@ -186,7 +186,7 @@ journey(app, {
       connect_timeout: 15000
     },
     cookie: {
-      secure: config.redis.useSSL === 'true'
+      secure: process.env.NODE_ENV !== 'development'
     },
     secret: config.redis.secret
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@hmcts/look-and-feel": "1.18.0",
     "@hmcts/nodejs-healthcheck": "^1.4.3",
     "@hmcts/nodejs-logging": "^3.0.0",
-    "@hmcts/one-per-page": "3.4.1",
+    "@hmcts/one-per-page": "3.4.3",
     "@hmcts/uk-bank-holidays": "^1.0.1",
     "accessible-autocomplete": "^1.6.1",
     "applicationinsights": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,9 +53,9 @@
     on-finished "^2.3.0"
     winston "^2.4.1"
 
-"@hmcts/one-per-page@3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@hmcts/one-per-page/-/one-per-page-3.4.1.tgz#8a93bff8545a8c6fdff68eaba3d3cfd9a283e7e6"
+"@hmcts/one-per-page@3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@hmcts/one-per-page/-/one-per-page-3.4.3.tgz#e0cce5886c840b5f26ab8cf92e00de138e6da147"
   dependencies:
     "@log4js-node/log4js-api" "^1.0.0"
     body-parser "^1.18.2"


### PR DESCRIPTION
Change logic around when to make the cookie secure. The previous way was not becoming truthy and so was not setting the secure flag on the cookie. This fixes that