### PR TITLE
SSCS-3509 Explicitly track exceptions in application insights

### DIFF
--- a/app-insights.js
+++ b/app-insights.js
@@ -1,9 +1,16 @@
 const applicationInsights = require('applicationinsights');
 const config = require('config');
 
-const appInsights = () => {
+const enable = () => {
   const iKey = config.get('appInsights.instrumentationKey');
   applicationInsights.setup(iKey).start();
 };
 
-module.exports = appInsights;
+const trackException = exception => {
+  applicationInsights.defaultClient.trackException({ exception });
+};
+
+module.exports = {
+  enable,
+  trackException
+};

--- a/app-insights.js
+++ b/app-insights.js
@@ -3,7 +3,7 @@ const config = require('config');
 
 const enable = () => {
   const iKey = config.get('appInsights.instrumentationKey');
-  applicationInsights.setup(iKey).start();
+  applicationInsights.setup(iKey).setAutoCollectConsole(true, true).start();
 };
 
 const trackException = exception => {

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-require('app-insights')();
+require('app-insights').enable();
 const { Logger, Express } = require('@hmcts/nodejs-logging');
 const { journey } = require('@hmcts/one-per-page');
 const lookAndFeel = require('@hmcts/look-and-feel');

--- a/steps/check-your-appeal/CheckYourAppeal.js
+++ b/steps/check-your-appeal/CheckYourAppeal.js
@@ -8,6 +8,7 @@ const { goTo, action } = require('@hmcts/one-per-page/flow');
 const { Logger } = require('@hmcts/nodejs-logging');
 const { lastName } = require('utils/regex');
 const sections = require('steps/check-your-appeal/sections');
+const appInsights = require('app-insights');
 const HttpStatus = require('http-status-codes');
 const request = require('superagent');
 const paths = require('paths');
@@ -33,6 +34,7 @@ class CheckYourAppeal extends CYA {
       this.logger.info(`POST api:${this.journey.settings.apiUrl} status:${result.status}`);
     }).catch(error => {
       const errMsg = `${error.message} status:${error.status || HttpStatus.INTERNAL_SERVER_ERROR}`;
+      appInsights.trackException(errMsg);
       this.logger.error(errMsg);
       return Promise.reject(error);
     });

--- a/steps/reasons-for-appealing/evidence-upload/EvidenceUpload.js
+++ b/steps/reasons-for-appealing/evidence-upload/EvidenceUpload.js
@@ -4,6 +4,7 @@ const { AddAnother } = require('@hmcts/one-per-page/steps');
 const { text, object } = require('@hmcts/one-per-page/forms');
 const { Logger } = require('@hmcts/nodejs-logging');
 const config = require('config');
+const appInsights = require('app-insights');
 
 const uploadEvidenceUrl = config.get('api.uploadEvidenceUrl');
 const maxFileSize = config.get('features.evidenceUpload.maxFileSize');
@@ -88,6 +89,7 @@ class EvidenceUpload extends AddAnother {
 
             return next();
           }
+          appInsights.trackException(forwardingError);
           return next(forwardingError);
         });
 


### PR DESCRIPTION
* adding `trackException` calls for issues connecting to the tribunals API
* this is done for evidence upload and submission