### PR TITLE
SSCS-3661 Post code checker says post code Not in England or Wales

### DIFF
--- a/mocks/postcode_checker/index.js
+++ b/mocks/postcode_checker/index.js
@@ -17,7 +17,7 @@ app.get('/regionalcentre/:postcode', (req, res) => {
   const cannedRes = {
     EH8: { status: HttpStatus.OK, body: { regionalCentre: 'Glasgow' } },
     ZX99: { status: HttpStatus.NOT_FOUND, body: { } },
-    default: { status: HttpStatus.OK, body: { regionalCentre: 'London' } }
+    default: { status: HttpStatus.OK, body: { regionalCentre: 'Birmingham' } }
   };
   const resJson = (postcode in cannedRes) ? cannedRes[postcode] : cannedRes.default;
 

--- a/steps/identity/appellant-contact-details/content.en.json
+++ b/steps/identity/appellant-contact-details/content.en.json
@@ -31,7 +31,7 @@
       "title": "Postcode",
       "error": {
         "required": "Enter the postcode from your address",
-        "invalidPostcode": "Postcode must be in England or Wales"
+        "invalidPostcode": "The online appeal service is not available to people from this region. This postcode should match the postcode you entered to access the service."
       }
     },
     "phoneNumber": {


### PR DESCRIPTION
- Changed error message
- Fixed stub postcode checker as by default it was returning an RPC that
we do not cover.