### PR TITLE
Bugfix postcode whitespace

### DIFF
--- a/steps/identity/appellant-contact-details/AppellantContactDetails.js
+++ b/steps/identity/appellant-contact-details/AppellantContactDetails.js
@@ -137,7 +137,9 @@ class AppellantContactDetails extends Question {
           townCity: this.fields.townCity.value,
           county: this.fields.county.value,
           postCode: this.fields.postCode.value.trim(),
-          phoneNumber: this.fields.phoneNumber.value,
+          phoneNumber: this.fields.phoneNumber.value ?
+            this.fields.phoneNumber.value.trim() :
+            this.fields.phoneNumber.value,
           emailAddress: this.fields.emailAddress.value
         }
       }

--- a/steps/identity/appellant-contact-details/AppellantContactDetails.js
+++ b/steps/identity/appellant-contact-details/AppellantContactDetails.js
@@ -136,7 +136,7 @@ class AppellantContactDetails extends Question {
           addressLine2: this.fields.addressLine2.value,
           townCity: this.fields.townCity.value,
           county: this.fields.county.value,
-          postCode: this.fields.postCode.value,
+          postCode: this.fields.postCode.value.trim(),
           phoneNumber: this.fields.phoneNumber.value,
           emailAddress: this.fields.emailAddress.value
         }

--- a/steps/identity/appellant-nino/AppellantNINO.js
+++ b/steps/identity/appellant-nino/AppellantNINO.js
@@ -33,7 +33,7 @@ class AppellantNINO extends Question {
   values() {
     return {
       appellant: {
-        nino: this.fields.nino.value
+        nino: this.fields.nino.value.trim()
       }
     };
   }

--- a/steps/representative/representative-details/RepresentativeDetails.js
+++ b/steps/representative/representative-details/RepresentativeDetails.js
@@ -131,8 +131,10 @@ class RepresentativeDetails extends Question {
           addressLine2: this.fields.addressLine2.value,
           townCity: this.fields.townCity.value,
           county: this.fields.county.value,
-          postCode: this.fields.postCode.value,
-          phoneNumber: this.fields.phoneNumber.value,
+          postCode: this.fields.postCode.value.trim(),
+          phoneNumber: this.fields.phoneNumber.value ?
+            this.fields.phoneNumber.value.trim() :
+            this.fields.phoneNumber.value,
           emailAddress: this.fields.emailAddress.value
         }
       }

--- a/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
+++ b/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
@@ -293,6 +293,13 @@ describe('AppellantContactDetails.js', () => {
       expect(postcode).to.not.equal(' Post code ');
       expect(postcode).to.equal('Post code');
     });
+
+    it('removes whitespace from before and after the phone number string', () => {
+      appellantContactDetails.fields.phoneNumber.value = ' 0800109756 ';
+      const phoneNumber = appellantContactDetails.values().appellant.contactDetails.phoneNumber;
+      expect(phoneNumber).to.not.equal(' 0800109756 ');
+      expect(phoneNumber).to.equal('0800109756');
+    });
   });
 
   describe('next()', () => {

--- a/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
+++ b/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
@@ -286,6 +286,13 @@ describe('AppellantContactDetails.js', () => {
         }
       });
     });
+
+    it('removes whitespace from before and after the postcode string', () => {
+      appellantContactDetails.fields.postCode.value = ' Post code ';
+      const postcode = appellantContactDetails.values().appellant.contactDetails.postCode;
+      expect(postcode).to.not.equal(' Post code ');
+      expect(postcode).to.equal('Post code');
+    });
   });
 
   describe('next()', () => {

--- a/test/unit/steps/identity/appellant-nino/AppellantNINO.test.js
+++ b/test/unit/steps/identity/appellant-nino/AppellantNINO.test.js
@@ -84,6 +84,13 @@ describe('AppellantNINO.js', () => {
       const values = appellantNINO.values();
       expect(values).to.eql({ appellant: { nino: value } });
     });
+
+    it('removes whitespace from before and after the nino string', () => {
+      appellantNINO.fields.nino.value = ' AB 123 456 C ';
+      const nino = appellantNINO.values().appellant.nino;
+      expect(nino).to.not.equal(' AB 123 456 C ');
+      expect(nino).to.equal('AB 123 456 C');
+    });
   });
 
   describe('next()', () => {

--- a/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
+++ b/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
@@ -298,6 +298,20 @@ describe('RepresentativeDetails.js', () => {
         }
       });
     });
+
+    it('removes whitespace from before and after the postcode string', () => {
+      representativeDetails.fields.postCode.value = ' Post code ';
+      const postcode = representativeDetails.values().representative.contactDetails.postCode;
+      expect(postcode).to.not.equal(' Post code ');
+      expect(postcode).to.equal('Post code');
+    });
+
+    it('removes whitespace from before and after the phone number string', () => {
+      representativeDetails.fields.phoneNumber.value = ' 0800109756 ';
+      const phoneNumber = representativeDetails.values().representative.contactDetails.phoneNumber;
+      expect(phoneNumber).to.not.equal(' 0800109756 ');
+      expect(phoneNumber).to.equal('0800109756');
+    });
   });
 
   describe('next()', () => {


### PR DESCRIPTION
Add trim to `value()` for:
- appellant contact details postcode,
- appellant contact details phone number,
- appellant nino,
- rep contact details postcode,
- rep contact details phone number

 This prevents whitespace errors in robotics.